### PR TITLE
Return 401 when bad credentials are passed

### DIFF
--- a/https/tls_config_test.go
+++ b/https/tls_config_test.go
@@ -375,8 +375,7 @@ func (test *TestInputs) Test(t *testing.T) {
 		}
 	}()
 
-	var server *http.Server
-	server = &http.Server{
+	server := &http.Server{
 		Addr: port,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("Hello World!"))

--- a/https/tls_config_test.go
+++ b/https/tls_config_test.go
@@ -555,7 +555,7 @@ func TestUsers(t *testing.T) {
 			UseTLSClient:   true,
 			Username:       "dave",
 			Password:       "bad",
-			ExpectedError:  ErrorMap["Forbidden"],
+			ExpectedError:  ErrorMap["Unauthorized"],
 		},
 		{
 			Name:           `with bad username and TLS`,
@@ -563,7 +563,7 @@ func TestUsers(t *testing.T) {
 			UseTLSClient:   true,
 			Username:       "nonexistent",
 			Password:       "nonexistent",
-			ExpectedError:  ErrorMap["Forbidden"],
+			ExpectedError:  ErrorMap["Unauthorized"],
 		},
 	}
 	for _, testInputs := range testTables {


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7235#section-3.1

> If the request included authentication credentials, then the 401
> response indicates that authorization has been refused for those
> credentials.

cc @SuperQ 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>