### PR TITLE
Limit basicauth cache size

### DIFF
--- a/web/cache.go
+++ b/web/cache.go
@@ -40,6 +40,9 @@ type cache struct {
 // machine is not compromised, at which point all bets are off, since basicauth
 // necessitates plaintext passwords being received over the wire anyway).
 func newCache(size int) *cache {
+	if size > cacheSize/10 {
+		size = cacheSize / 10
+	}
 	return &cache{
 		cache: make(map[string]bool, size),
 	}


### PR DESCRIPTION
If you ended up with 1000 users in your web config, we would have
pre-allocated a map with 1000 entries. The maximum size of the map is
currently hardcoded to 100, so 900 of the preallocations would never be
used.

This limits the initial pre-allocation to 10% of the map size, which is
at this moment 10.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>