### PR TITLE
Fix ClientAuth type typo

### DIFF
--- a/web/testdata/tls_config_noAuth.requireanyclientcert.good.yml
+++ b/web/testdata/tls_config_noAuth.requireanyclientcert.good.yml
@@ -1,0 +1,5 @@
+tls_server_config:
+  cert_file: "server.crt"
+  key_file: "server.key"
+  client_auth_type: "RequireAnyClientCert"
+  client_ca_file: "tls-ca-chain.pem"

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -154,7 +154,7 @@ func ConfigToTLSConfig(c *TLSStruct) (*tls.Config, error) {
 	switch c.ClientAuth {
 	case "RequestClientCert":
 		cfg.ClientAuth = tls.RequestClientCert
-	case "RequireClientCert":
+	case "RequireAnyClientCert", "RequireClientCert": // Preserved for backwards compatibility.
 		cfg.ClientAuth = tls.RequireAnyClientCert
 	case "VerifyClientCertIfGiven":
 		cfg.ClientAuth = tls.VerifyClientCertIfGiven

--- a/web/tls_config_test.go
+++ b/web/tls_config_test.go
@@ -53,6 +53,7 @@ var (
 		"Unknown TLS version":          regexp.MustCompile(`unknown TLS version`),
 		"No HTTP2 cipher":              regexp.MustCompile(`TLSConfig.CipherSuites is missing an HTTP/2-required`),
 		"Incompatible TLS version":     regexp.MustCompile(`protocol version not supported`),
+		"Bad certificate":              regexp.MustCompile(`bad certificate`),
 	}
 )
 
@@ -279,6 +280,12 @@ func TestServerBehaviour(t *testing.T) {
 			YAMLConfigPath: "testdata/tls_config_noAuth_noHTTP2Cipher.bad.yml",
 			UseTLSClient:   true,
 			ExpectedError:  ErrorMap["No HTTP2 cipher"],
+		},
+		{
+			Name:           `valid tls config yml and tls client with RequireAnyClientCert`,
+			YAMLConfigPath: "testdata/tls_config_noAuth.requireanyclientcert.good.yml",
+			UseTLSClient:   true,
+			ExpectedError:  ErrorMap["Bad certificate"],
 		},
 	}
 	for _, testInputs := range testTables {


### PR DESCRIPTION
`RequireAnyClientCert` is the actual name, not `RequireClientCert`

Fixes prometheus/prometheus#9066


