### PR TITLE
Remove unused `lint` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,13 +5,6 @@ orbs:
   go: circleci/go@0.2.0
 
 jobs:
-  lint:
-    docker:
-    - image: circleci/golang:1.15
-    working_directory: /go/src/github.com/prometheus/exporter-toolkit
-    steps:
-    - checkout
-    - run: make lint
   test:
     parameters:
       go_version:
@@ -42,8 +35,7 @@ workflows:
   version: 2
   tests:
     jobs:
-    # Support the last two go relases, as per https://golang.org/dl/
-    - lint
+    # Support the last two go releases, as per https://golang.org/dl/.
     - test:
         name: go-1-14
         go_version: "1.14"


### PR DESCRIPTION
After the merge of https://github.com/prometheus/exporter-toolkit/pull/64, golangci-lint is run a GitHub Action instead of CircleCI. Now, the `lint` job doesn't do anything: https://app.circleci.com/pipelines/github/prometheus/exporter-toolkit/155/workflows/9a5f9807-a960-49a6-a148-d048b383735d/jobs/419/parallel-runs/0/steps/0-102.