### PR TITLE
Fix a bug where HTTP 2 connections were not working

### DIFF
--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -240,7 +240,12 @@ func Serve(l net.Listener, server *http.Server, tlsConfigPath string, logger log
 	// Set the GetConfigForClient method of the HTTPS server so that the config
 	// and certs are reloaded on new connections.
 	server.TLSConfig.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
-		return getTLSConfig(tlsConfigPath)
+		config, err := getTLSConfig(tlsConfigPath)
+		if err != nil {
+			return nil, err
+		}
+		config.NextProtos = server.TLSConfig.NextProtos
+		return config, nil
 	}
 	return server.ServeTLS(l, "", "")
 }


### PR DESCRIPTION
Hi, maintainers (@SuperQ and @roidelapluie).

This PR fixes an issue in exporter-toolkit where it always overrides the `NextProtos` field in `TLSConfig` for every request and results in HTTP/1.1 even though HTTP 2 is enabled by default. The current implementation around `GetConfigForClient` always overrides `NextProtos` field that is internally set to `[]string{"h2", "http/1.1"}` when initializing server in `net/http`:
https://github.com/golang/go/blob/go1.17.3/src/net/http/h2_bundle.go#L6817-L6822

---

To simply reproduce this issue, use this snippet of code:

```go
package main

import (
	"fmt"
	"net/http"
	"os"

	"github.com/go-kit/log"
	"github.com/prometheus/exporter-toolkit/web"
)

func main() {
	handler := http.NewServeMux()
	handler.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		fmt.Fprintf(w, "Hello, world!\n")
	})
	server := &http.Server{
		Addr:    "[::]:4443",
		Handler: handler,
	}

	err := web.ListenAndServe(server, "config.yaml", log.NewLogfmtLogger(os.Stdout))
	if err != nil {
		fmt.Printf("server: %#v\n", server)
		panic(err)
	}
}
```

```yaml
tls_server_config:
  cert_file: tls.crt
  key_file: tls.key
```