### PR TITLE
Ignore unknown fields in config file

### DIFF
--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -76,7 +76,7 @@ func getConfig(configPath string) (*Config, error) {
 		},
 		HTTPConfig: HTTPStruct{HTTP2: true},
 	}
-	err = yaml.UnmarshalStrict(content, c)
+	err = yaml.Unmarshal(content, c)
 	if err == nil {
 		err = validateHeaderConfig(c.HTTPConfig.Header)
 	}


### PR DESCRIPTION
Hi, I would like to use the exporter-toolkit in one of my projects. The [project](https://github.com/ricoberger/script_exporter) already uses a config file for some configuration options.

To not handle multiple configuration files I would like to use a config struct like the following:

```go
package config

import (
	"io/ioutil"

	"github.com/prometheus/exporter-toolkit/web"
	"gopkg.in/yaml.v2"
)

type Config struct {
	web.Config

	Discovery struct {
		Host   string `yaml:"host"`
		Port   string `yaml:"port"`
		Scheme string `yaml:"scheme"`
	} `yaml:"discovery"`

	Scripts []struct {
		Name    string `yaml:"name"`
		Script  string `yaml:"script"`
		Timeout Timeout
	} `yaml:"scripts"`
}
```

So that I can use the same configuration file for the exporter specific stuff and the configuration of the exporter-toolkit.

This is currently not possible, because the exporter-toolkit uses `yaml.UnmarshalStrict` for parsing the yaml file, which then throws the following error:

```
&yaml.TypeError{Errors:[]string{"line 1: field discovery not found in type web.Config", "line 6: field scripts not found in type web.Config"}}
```

To only use one configuration file it would be nice if we can change `yaml.UnmarshalStrict` to `yaml.Unmarshal`.

Another approach could be to not handle the parsing of the config file within the exporter-toolkit and instead allow users to pass the config to the `ListenAndServe` function:

```diff
-func web.ListenAndServe(server *http.Server, tlsConfigPath string, logger log.Logger) error
+func web.ListenAndServe(server *http.Server, config web.Config, logger log.Logger) error
``` 

What do you think about this?