### PR TITLE
Update for Go 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@0.2.0
+  go: circleci/go@1.7.1
 
 jobs:
   test:
@@ -13,8 +13,10 @@ jobs:
         type: boolean
         default: true
     docker:
-    - image: circleci/golang:<< parameters.go_version >>
-    working_directory: /go/src/github.com/prometheus/exporter-toolkit
+    - image: cimg/go:<< parameters.go_version >>
+    environment:
+      # Override Go 1.18 security deprecations.
+      GODEBUG: "x509sha1=1,tls10default=1"
     steps:
     - checkout
     - when:
@@ -37,8 +39,8 @@ workflows:
     jobs:
     # Support the last two go releases, as per https://golang.org/dl/.
     - test:
-        name: go-1-16
-        go_version: "1.16"
-    - test:
         name: go-1-17
         go_version: "1.17"
+    - test:
+        name: go-1-18
+        go_version: "1.18"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/exporter-toolkit
 
-go 1.14
+go 1.17
 
 require (
 	github.com/go-kit/log v0.2.0
@@ -9,4 +9,25 @@ require (
 	golang.org/x/crypto v0.0.0-20220128200615-198e4374d7ed
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
+	github.com/prometheus/client_golang v1.12.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 )


### PR DESCRIPTION
* Update tests for Go 1.17/1.18.
* `go mod tidy -go=1.17`

Signed-off-by: SuperQ <superq@gmail.com>