### PR TITLE
docs: clarify supported tls cipher suites

### DIFF
--- a/docs/web-configuration.md
+++ b/docs/web-configuration.md
@@ -48,6 +48,9 @@ tls_server_config:
   # Go default cipher suites are used. Available cipher suites are documented
   # in the go documentation:
   # https://golang.org/pkg/crypto/tls/#pkg-constants
+  #
+  # Note that only the cipher returned by the following function are supported:
+  # https://pkg.go.dev/crypto/tls#CipherSuites
   [ cipher_suites:
     [ - <string> ] ]
 


### PR DESCRIPTION
Addresses [this issue](https://github.com/prometheus/prometheus/issues/10852) from the Prometheus repo for the exporter-toolkit repo.

Signed-off-by: Alex Gavin <a_gavin@icloud.com>