### PR TITLE
Allow TLS parameters to be set in code

### DIFF
--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -44,10 +44,10 @@ type TLSStruct struct {
 	TLSKeyPath               string     `yaml:"key_file"`
 	ClientAuth               string     `yaml:"client_auth_type"`
 	ClientCAs                string     `yaml:"client_ca_file"`
-	CipherSuites             []cipher   `yaml:"cipher_suites"`
-	CurvePreferences         []curve    `yaml:"curve_preferences"`
-	MinVersion               tlsVersion `yaml:"min_version"`
-	MaxVersion               tlsVersion `yaml:"max_version"`
+	CipherSuites             []Cipher   `yaml:"cipher_suites"`
+	CurvePreferences         []Curve    `yaml:"curve_preferences"`
+	MinVersion               TLSVersion `yaml:"min_version"`
+	MaxVersion               TLSVersion `yaml:"max_version"`
 	PreferServerCipherSuites bool       `yaml:"prefer_server_cipher_suites"`
 }
 
@@ -264,9 +264,9 @@ func Validate(tlsConfigPath string) error {
 	return err
 }
 
-type cipher uint16
+type Cipher uint16
 
-func (c *cipher) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Cipher) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	err := unmarshal((*string)(&s))
 	if err != nil {
@@ -274,27 +274,27 @@ func (c *cipher) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	for _, cs := range tls.CipherSuites() {
 		if cs.Name == s {
-			*c = (cipher)(cs.ID)
+			*c = (Cipher)(cs.ID)
 			return nil
 		}
 	}
 	return errors.New("unknown cipher: " + s)
 }
 
-func (c cipher) MarshalYAML() (interface{}, error) {
+func (c Cipher) MarshalYAML() (interface{}, error) {
 	return tls.CipherSuiteName((uint16)(c)), nil
 }
 
-type curve tls.CurveID
+type Curve tls.CurveID
 
-var curves = map[string]curve{
-	"CurveP256": (curve)(tls.CurveP256),
-	"CurveP384": (curve)(tls.CurveP384),
-	"CurveP521": (curve)(tls.CurveP521),
-	"X25519":    (curve)(tls.X25519),
+var curves = map[string]Curve{
+	"CurveP256": (Curve)(tls.CurveP256),
+	"CurveP384": (Curve)(tls.CurveP384),
+	"CurveP521": (Curve)(tls.CurveP521),
+	"X25519":    (Curve)(tls.X25519),
 }
 
-func (c *curve) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Curve) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	err := unmarshal((*string)(&s))
 	if err != nil {
@@ -307,7 +307,7 @@ func (c *curve) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return errors.New("unknown curve: " + s)
 }
 
-func (c *curve) MarshalYAML() (interface{}, error) {
+func (c *Curve) MarshalYAML() (interface{}, error) {
 	for s, curveid := range curves {
 		if *c == curveid {
 			return s, nil
@@ -316,16 +316,16 @@ func (c *curve) MarshalYAML() (interface{}, error) {
 	return fmt.Sprintf("%v", c), nil
 }
 
-type tlsVersion uint16
+type TLSVersion uint16
 
-var tlsVersions = map[string]tlsVersion{
-	"TLS13": (tlsVersion)(tls.VersionTLS13),
-	"TLS12": (tlsVersion)(tls.VersionTLS12),
-	"TLS11": (tlsVersion)(tls.VersionTLS11),
-	"TLS10": (tlsVersion)(tls.VersionTLS10),
+var tlsVersions = map[string]TLSVersion{
+	"TLS13": (TLSVersion)(tls.VersionTLS13),
+	"TLS12": (TLSVersion)(tls.VersionTLS12),
+	"TLS11": (TLSVersion)(tls.VersionTLS11),
+	"TLS10": (TLSVersion)(tls.VersionTLS10),
 }
 
-func (tv *tlsVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (tv *TLSVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	err := unmarshal((*string)(&s))
 	if err != nil {
@@ -338,7 +338,7 @@ func (tv *tlsVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return errors.New("unknown TLS version: " + s)
 }
 
-func (tv *tlsVersion) MarshalYAML() (interface{}, error) {
+func (tv *TLSVersion) MarshalYAML() (interface{}, error) {
 	for s, v := range tlsVersions {
 		if *tv == v {
 			return s, nil


### PR DESCRIPTION
By exporting the type, it becomes possible to construct a value in code outside this package, and pass in to the toolkit.

Fixes #109 
