### PR TITLE
Update golangci linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 linters:
   enable:
-  - golint
+  - revive
 
 issues:
   exclude-rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,7 @@
 linters:
   enable:
+  - goimports
+  - misspell
   - revive
 
 issues:

--- a/web/tls_config_test.go
+++ b/web/tls_config_test.go
@@ -308,7 +308,7 @@ func TestServerBehaviour(t *testing.T) {
 			ExpectedError:  ErrorMap["Invalid value"],
 		},
 		{
-			Name:           `HTTP header that can not be overriden`,
+			Name:           `HTTP header that can not be overridden`,
 			YAMLConfigPath: "testdata/web_config_headers_extra_header.bad.yml",
 			ExpectedError:  ErrorMap["Invalid header"],
 		},


### PR DESCRIPTION
Replace deprecated golint with revive

Add goimports and misspell linters as they are used in https://github.com/prometheus/prometheus/blob/main/.golangci.yml