### PR TITLE
Add a Content-Type header to the landing page

### DIFF
--- a/web/landing_page.go
+++ b/web/landing_page.go
@@ -78,5 +78,6 @@ func NewLandingPage(c LandingConfig) (*LandingPageHandler, error) {
 }
 
 func (h *LandingPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "text/html; charset=UTF-8")
 	w.Write(h.landingPage)
 }


### PR DESCRIPTION
Set the landing page Content-Type header to HTML.