### PR TITLE
Refer user to doco from help message

### DIFF
--- a/web/kingpinflag/flag.go
+++ b/web/kingpinflag/flag.go
@@ -38,7 +38,7 @@ func AddFlags(a *kingpin.Application, defaultAddress string) *web.FlagConfig {
 		WebSystemdSocket: systemdSocket,
 		WebConfigFile: a.Flag(
 			"web.config.file",
-			"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.",
+			"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication. See: https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md",
 		).Default("").String(),
 	}
 	return &flags


### PR DESCRIPTION
The help message generated by the toolkit leaves users with no hints about what to put in the `web.config.file`. Because this toolkit is designed to be embedded in other projects, it would be non-obvious for a user to know to come to this repo and examine the docs folder.

This PR assumes that `/docs/web-configuration.md` is intended to be a stable URL and directs users to it so they know how to populate the file.

Tagging @SuperQ and @roidelapluie per `CONTRIBUTING.md`