### PR TITLE
Remove experimental in CLI

### DIFF
--- a/web/kingpinflag/flag.go
+++ b/web/kingpinflag/flag.go
@@ -38,7 +38,7 @@ func AddFlags(a *kingpin.Application, defaultAddress string) *web.FlagConfig {
 		WebSystemdSocket: systemdSocket,
 		WebConfigFile: a.Flag(
 			"web.config.file",
-			"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication. See: https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md",
+			"Path to configuration file that can enable TLS or authentication. See: https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md",
 		).Default("").String(),
 	}
 	return &flags


### PR DESCRIPTION
Removes experimental from the CLI flag, as it has been there for 3 years now.