### PR TITLE
Update to yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/prometheus/common v0.58.0
 	golang.org/x/crypto v0.26.0
 	golang.org/x/sync v0.8.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -30,4 +30,5 @@ require (
 	golang.org/x/sys v0.23.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/web/tls_config_test.go
+++ b/web/tls_config_test.go
@@ -45,6 +45,7 @@ var (
 	testlogger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	ErrorMap = map[string]*regexp.Regexp{
+		"End of file":                  regexp.MustCompile(`EOF`),
 		"HTTP Response to HTTPS":       regexp.MustCompile(`server gave HTTP response to HTTPS client`),
 		"No such file":                 regexp.MustCompile(`no such file`),
 		"Invalid argument":             regexp.MustCompile(`invalid argument`),
@@ -110,7 +111,7 @@ func TestYAMLFiles(t *testing.T) {
 		{
 			Name:           `empty config yml`,
 			YAMLConfigPath: "testdata/web_config_empty.yml",
-			ExpectedError:  nil,
+			ExpectedError:  ErrorMap["End of file"],
 		},
 		{
 			Name:           `invalid config yml (invalid structure)`,


### PR DESCRIPTION
Also, modify `empty_config_yml` because with yaml.v3 reading empty file causes Decode to return EOF error, as described in https://github.com/go-yaml/yaml/issues/805 issue.