### PR TITLE
Split TLS client tests to handle Go 1.21+ error strings

### DIFF
--- a/web/tls_config_go118_test.go
+++ b/web/tls_config_go118_test.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.18 && !go1.21
+// +build go1.18,!go1.21
+
+package web
+
+import (
+	"testing"
+)
+
+func TestServerBehaviour118(t *testing.T) {
+	testTables := []*TestInputs{
+		{
+			Name:           `valid tls config yml and tls client with RequireAnyClientCert`,
+			YAMLConfigPath: "testdata/tls_config_noAuth.requireanyclientcert.good.yml",
+			UseTLSClient:   true,
+			ExpectedError:  ErrorMap["Bad certificate"],
+		},
+		{
+			Name:           `valid tls config yml and tls client with RequireAndVerifyClientCert`,
+			YAMLConfigPath: "testdata/tls_config_noAuth.requireandverifyclientcert.good.yml",
+			UseTLSClient:   true,
+			ExpectedError:  ErrorMap["Bad certificate"],
+		},
+		{
+			Name:              `valid tls config yml and tls client with RequireAndVerifyClientCert (present wrong certificate)`,
+			YAMLConfigPath:    "testdata/tls_config_noAuth.requireandverifyclientcert.good.yml",
+			UseTLSClient:      true,
+			ClientCertificate: "client2_selfsigned",
+			ExpectedError:     ErrorMap["Bad certificate"],
+		},
+	}
+	for _, testInputs := range testTables {
+		t.Run(testInputs.Name, testInputs.Test)
+	}
+}

--- a/web/tls_config_go118_test.go
+++ b/web/tls_config_go118_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Prometheus Authors
+// Copyright 2023 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/web/tls_config_go121_test.go
+++ b/web/tls_config_go121_test.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.21
+// +build go1.21
+
+package web
+
+import (
+	"testing"
+)
+
+func TestServerBehaviour121(t *testing.T) {
+	testTables := []*TestInputs{
+		{
+			Name:           `valid tls config yml and tls client with RequireAnyClientCert`,
+			YAMLConfigPath: "testdata/tls_config_noAuth.requireanyclientcert.good.yml",
+			UseTLSClient:   true,
+			ExpectedError:  ErrorMap["Certificate required"],
+		},
+		{
+			Name:           `valid tls config yml and tls client with RequireAndVerifyClientCert`,
+			YAMLConfigPath: "testdata/tls_config_noAuth.requireandverifyclientcert.good.yml",
+			UseTLSClient:   true,
+			ExpectedError:  ErrorMap["Certificate required"],
+		},
+		{
+			Name:              `valid tls config yml and tls client with RequireAndVerifyClientCert (present wrong certificate)`,
+			YAMLConfigPath:    "testdata/tls_config_noAuth.requireandverifyclientcert.good.yml",
+			UseTLSClient:      true,
+			ClientCertificate: "client2_selfsigned",
+			ExpectedError:     ErrorMap["Unknown CA"],
+		},
+	}
+	for _, testInputs := range testTables {
+		t.Run(testInputs.Name, testInputs.Test)
+	}
+}

--- a/web/tls_config_go121_test.go
+++ b/web/tls_config_go121_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Prometheus Authors
+// Copyright 2023 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/web/tls_config_test.go
+++ b/web/tls_config_test.go
@@ -68,6 +68,9 @@ var (
 		"Invalid value":            regexp.MustCompile(`invalid value for`),
 		"Invalid header":           regexp.MustCompile(`HTTP header ".*" can not be configured`),
 		"Invalid client cert":      regexp.MustCompile(`bad certificate`),
+		// Introduced in Go 1.21
+		"Certificate required": regexp.MustCompile(`certificate required`),
+		"Unknown CA":           regexp.MustCompile(`unknown certificate authority`),
 	}
 )
 
@@ -313,12 +316,6 @@ func TestServerBehaviour(t *testing.T) {
 			ExpectedError:  ErrorMap["No HTTP2 cipher"],
 		},
 		{
-			Name:           `valid tls config yml and tls client with RequireAnyClientCert`,
-			YAMLConfigPath: "testdata/tls_config_noAuth.requireanyclientcert.good.yml",
-			UseTLSClient:   true,
-			ExpectedError:  ErrorMap["Bad certificate"],
-		},
-		{
 			Name:           `valid headers config`,
 			YAMLConfigPath: "testdata/web_config_headers.good.yml",
 		},
@@ -352,24 +349,11 @@ func TestServerBehaviour(t *testing.T) {
 			ExpectedError:     nil,
 		},
 		{
-			Name:           `valid tls config yml and tls client with RequireAndVerifyClientCert`,
-			YAMLConfigPath: "testdata/tls_config_noAuth.requireandverifyclientcert.good.yml",
-			UseTLSClient:   true,
-			ExpectedError:  ErrorMap["Bad certificate"],
-		},
-		{
 			Name:              `valid tls config yml and tls client with RequireAndVerifyClientCert (present certificate)`,
 			YAMLConfigPath:    "testdata/tls_config_noAuth.requireandverifyclientcert.good.yml",
 			UseTLSClient:      true,
 			ClientCertificate: "client_selfsigned",
 			ExpectedError:     nil,
-		},
-		{
-			Name:              `valid tls config yml and tls client with RequireAndVerifyClientCert (present wrong certificate)`,
-			YAMLConfigPath:    "testdata/tls_config_noAuth.requireandverifyclientcert.good.yml",
-			UseTLSClient:      true,
-			ClientCertificate: "client2_selfsigned",
-			ExpectedError:     ErrorMap["Bad certificate"],
 		},
 		{
 			Name:              `valid tls config yml and tls client with VerifyPeerCertificate (present good SAN DNS entry)`,


### PR DESCRIPTION
Go 1.21 introduced more granular / specific error strings for certain "bad certificate" scenarios[1]. As such, we need to split these tests and conditionally compile based on build tags.

Fixes: #171, #187

[1]: https://github.com/golang/go/commit/62a994837a57a7d0c58bb364b580a389488446c9