### PR TITLE
Add pprof links to landing page

### DIFF
--- a/web/landing_page.css
+++ b/web/landing_page.css
@@ -15,4 +15,9 @@ label {
   display: inline-block;
   width: {{.Form.Width}}em;
 }
+#pprof {
+  border: black 2px solid;
+  padding: 1rem;
+  width: fit-content;
+}
 {{.ExtraCSS}}

--- a/web/landing_page.html
+++ b/web/landing_page.html
@@ -30,6 +30,14 @@
       </div>
       {{ end }}
       {{ .ExtraHTML }}
+      <div id="pprof">
+      Download a detailed report of resource usage (pprof format, from the Go runtime):
+      <ul>
+        <li><a href="debug/pprof/heap">heap usage (memory)</a>
+        <li><a href="debug/pprof/profile?seconds=60">CPU usage (60 second profile)</a>
+      </ul>
+      To visualize and share profiles you can upload to <a href="https://pprof.me" target="_blank">pprof.me</a>
+      </div>
     </main>
   </body>
 </html>


### PR DESCRIPTION
Make it easier for users to fetch and download pprof data for debugging.
* Add a link to https://pprof.me for easy sharing.

![image](https://github.com/prometheus/exporter-toolkit/assets/1320667/d70bf20d-34e8-47e2-bd8c-445c966597da)
