### PR TITLE
Only display landing page on /

### DIFF
--- a/web/landing_page.go
+++ b/web/landing_page.go
@@ -106,6 +106,10 @@ func NewLandingPage(c LandingConfig) (*LandingPageHandler, error) {
 }
 
 func (h *LandingPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
 	w.Header().Add("Content-Type", "text/html; charset=UTF-8")
 	w.Write(h.landingPage)
 }


### PR DESCRIPTION
This would fix #241 we ran into this issue when some of our automated tests fully believed that node exporter was leaking a linux home directory as it was returning HTTP 200 on requests like .bash_history