### PR TITLE
Feat: add possibility to disable pprof form

### DIFF
--- a/web/landing_page.go
+++ b/web/landing_page.go
@@ -27,15 +27,16 @@ import (
 
 // Config represents the configuration of the web listener.
 type LandingConfig struct {
-	HeaderColor string         // Used for the landing page header.
-	CSS         string         // CSS style tag for the landing page.
-	Name        string         // The name of the exporter, generally suffixed by _exporter.
-	Description string         // A short description about the exporter.
-	Form        LandingForm    // A POST form.
-	Links       []LandingLinks // Links displayed on the landing page.
-	ExtraHTML   string         // Additional HTML to be embedded.
-	ExtraCSS    string         // Additional CSS to be embedded.
-	Version     string         // The version displayed.
+	HeaderColor      string         // Used for the landing page header.
+	CSS              string         // CSS style tag for the landing page.
+	Name             string         // The name of the exporter, generally suffixed by _exporter.
+	Description      string         // A short description about the exporter.
+	Form             LandingForm    // A POST form.
+	Links            []LandingLinks // Links displayed on the landing page.
+	ExtraHTML        string         // Additional HTML to be embedded.
+	ExtraCSS         string         // Additional CSS to be embedded.
+	Version          string         // The version displayed.
+	DisablePprofForm bool           // Disable pprof report form
 }
 
 // LandingForm provides a configuration struct for creating a POST form on the landing page.

--- a/web/landing_page.html
+++ b/web/landing_page.html
@@ -30,6 +30,7 @@
       </div>
       {{ end }}
       {{ .ExtraHTML }}
+      {{ if not .DisablePprofForm }}
       <div id="pprof">
       Download a detailed report of resource usage (pprof format, from the Go runtime):
       <ul>
@@ -38,6 +39,7 @@
       </ul>
       To visualize and share profiles you can upload to <a href="https://pprof.me" target="_blank">pprof.me</a>
       </div>
+      {{ end }}
     </main>
   </body>
 </html>


### PR DESCRIPTION
This pull request introduces a feature to disable the `pprof` form on the landing page.

The new `DisablePprofForm` boolean parameter defaults to false, ensuring backward compatibility with existing behavior.
