### PR TITLE
Serve behind route prefix

### DIFF
--- a/web/landing_page.go
+++ b/web/landing_page.go
@@ -61,7 +61,8 @@ type LandingLinks struct {
 }
 
 type LandingPageHandler struct {
-	landingPage []byte
+	landingPage   []byte
+	routePrefixed bool
 }
 
 var (
@@ -71,7 +72,7 @@ var (
 	landingPagecssContent string
 )
 
-func NewLandingPage(c LandingConfig) (*LandingPageHandler, error) {
+func NewLandingPage(c LandingConfig, routePrefixed bool) (*LandingPageHandler, error) {
 	var buf bytes.Buffer
 
 	length := 0
@@ -101,12 +102,13 @@ func NewLandingPage(c LandingConfig) (*LandingPageHandler, error) {
 	}
 
 	return &LandingPageHandler{
-		landingPage: buf.Bytes(),
+		landingPage:   buf.Bytes(),
+		routePrefixed: routePrefixed,
 	}, nil
 }
 
 func (h *LandingPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Path != "/" {
+	if !h.routePrefixed && r.URL.Path != "/" {
 		http.NotFound(w, r)
 		return
 	}

--- a/web/landing_page.go
+++ b/web/landing_page.go
@@ -64,6 +64,7 @@ type LandingLinks struct {
 
 type LandingPageHandler struct {
 	landingPage []byte
+	routePrefix string
 }
 
 var (
@@ -111,10 +112,15 @@ func NewLandingPage(c LandingConfig) (*LandingPageHandler, error) {
 
 	return &LandingPageHandler{
 		landingPage: buf.Bytes(),
+		routePrefix: c.RoutePrefix,
 	}, nil
 }
 
 func (h *LandingPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != h.routePrefix {
+		http.NotFound(w, r)
+		return
+	}
 	w.Header().Add("Content-Type", "text/html; charset=UTF-8")
 	w.Write(h.landingPage)
 }

--- a/web/landing_page.go
+++ b/web/landing_page.go
@@ -98,6 +98,8 @@ func NewLandingPage(c LandingConfig) (*LandingPageHandler, error) {
 	}
 	if c.RoutePrefix == "" {
 		c.RoutePrefix = "/"
+	} else if !strings.HasSuffix(c.RoutePrefix, "/") {
+		c.RoutePrefix += "/"
 	}
 	// Strip leading '/' from Links if present
 	for i, link := range c.Links {

--- a/web/landing_page.go
+++ b/web/landing_page.go
@@ -22,11 +22,13 @@ import (
 	"bytes"
 	_ "embed"
 	"net/http"
+	"strings"
 	"text/template"
 )
 
 // Config represents the configuration of the web listener.
 type LandingConfig struct {
+	RoutePrefix string         // The route prefix for the exporter.
 	HeaderColor string         // Used for the landing page header.
 	CSS         string         // CSS style tag for the landing page.
 	Name        string         // The name of the exporter, generally suffixed by _exporter.
@@ -61,8 +63,7 @@ type LandingLinks struct {
 }
 
 type LandingPageHandler struct {
-	landingPage   []byte
-	routePrefixed bool
+	landingPage []byte
 }
 
 var (
@@ -72,7 +73,7 @@ var (
 	landingPagecssContent string
 )
 
-func NewLandingPage(c LandingConfig, routePrefixed bool) (*LandingPageHandler, error) {
+func NewLandingPage(c LandingConfig) (*LandingPageHandler, error) {
 	var buf bytes.Buffer
 
 	length := 0
@@ -94,6 +95,13 @@ func NewLandingPage(c LandingConfig, routePrefixed bool) (*LandingPageHandler, e
 		}
 		c.CSS = buf.String()
 	}
+	if c.RoutePrefix == "" {
+		c.RoutePrefix = "/"
+	}
+	// Strip leading '/' from Links if present
+	for i, link := range c.Links {
+		c.Links[i].Address = strings.TrimPrefix(link.Address, "/")
+	}
 	t := template.Must(template.New("landing page").Parse(landingPagehtmlContent))
 
 	buf.Reset()
@@ -102,16 +110,11 @@ func NewLandingPage(c LandingConfig, routePrefixed bool) (*LandingPageHandler, e
 	}
 
 	return &LandingPageHandler{
-		landingPage:   buf.Bytes(),
-		routePrefixed: routePrefixed,
+		landingPage: buf.Bytes(),
 	}, nil
 }
 
 func (h *LandingPageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if !h.routePrefixed && r.URL.Path != "/" {
-		http.NotFound(w, r)
-		return
-	}
 	w.Header().Add("Content-Type", "text/html; charset=UTF-8")
 	w.Write(h.landingPage)
 }

--- a/web/landing_page.html
+++ b/web/landing_page.html
@@ -15,13 +15,13 @@
       <div>
         <ul>
           {{ range .Links }}
-          <li><a href="{{ .Address }}">{{.Text}}</a>{{if .Description}}: {{.Description}}{{end}}</li>
+          <li><a href="{{if $.RoutePrefix}}{{ $.RoutePrefix }}{{end}}{{ .Address }}">{{.Text}}</a>{{if .Description}}: {{.Description}}{{end}}</li>
           {{ end }}
         </ul>
       </div>
       {{ if .Form.Action }}
       <div>
-      <form action="{{ .Form.Action}}">
+      <form action="{{if $.RoutePrefix}}{{ $.RoutePrefix }}{{end}}{{ .Form.Action }}">
       {{ range .Form.Inputs }}
       <label>{{ .Label }}:</label>&nbsp;<input type="{{ .Type }}" name="{{ .Name }}" placeholder="{{ .Placeholder }}" value="{{ .Value }}"><br>
       {{ end }}
@@ -33,8 +33,8 @@
       <div id="pprof">
       Download a detailed report of resource usage (pprof format, from the Go runtime):
       <ul>
-        <li><a href="debug/pprof/heap">heap usage (memory)</a>
-        <li><a href="debug/pprof/profile?seconds=60">CPU usage (60 second profile)</a>
+        <li><a href="{{if $.RoutePrefix}}{{ $.RoutePrefix }}{{end}}debug/pprof/heap">heap usage (memory)</a>
+        <li><a href="{{if $.RoutePrefix}}{{ $.RoutePrefix }}{{end}}debug/pprof/profile?seconds=60">CPU usage (60 second profile)</a>
       </ul>
       To visualize and share profiles you can upload to <a href="https://pprof.me" target="_blank">pprof.me</a>
       </div>


### PR DESCRIPTION
This new parameter will allow for serving the landing page when using --web.external-url as an argument with many exporters. 

I added this as it is needed for this pull request: https://github.com/prometheus/snmp_exporter/pull/1335

So in practice it will look something like this:

```go
landingConfig := web.LandingConfig{
        // config stuff goes here ...
		}
                                                                      // new parameter
		landingPage, err := web.NewLandingPage(landingConfig, *routePrefix != "")
		if err != nil {
			logger.Error("Error creating landing page", "err", err)
			os.Exit(1)
		}
		http.Handle(*routePrefix, landingPage)
```



