### PR TITLE
Allow `web.listen-address` to be unix domain sockets

### DIFF
--- a/web/kingpinflag/flag.go
+++ b/web/kingpinflag/flag.go
@@ -39,7 +39,7 @@ func AddFlags(a flagGroup, defaultAddress string) *web.FlagConfig {
 	flags := web.FlagConfig{
 		WebListenAddresses: a.Flag(
 			"web.listen-address",
-			"Addresses on which to expose metrics and web interface. Repeatable for multiple addresses. Examples: `:9100` or `[::1]:9100` for http, `vsock://:9100` for vsock",
+			"Addresses on which to expose metrics and web interface. Repeatable for multiple addresses. Examples: `:9100` or `[::1]:9100` for http, `vsock://:9100` for vsock, `unix:/var/run/prom.sock` for unix domain sockets",
 		).Default(defaultAddress).HintOptions(defaultAddress).Strings(),
 		WebSystemdSocket: systemdSocket,
 		WebConfigFile: a.Flag(

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -313,6 +313,12 @@ func ListenAndServe(server *http.Server, flags *FlagConfig, logger *slog.Logger)
 			if err != nil {
 				return err
 			}
+		} else if strings.HasPrefix(address, "unix:") {
+			path := address[5:]
+			listener, err = net.Listen("unix", path)
+			if err != nil {
+				return err
+			}
 		} else {
 			listener, err = net.Listen("tcp", address)
 			if err != nil {


### PR DESCRIPTION
 ## Context / Background
Prometheus push gateway is used extensively in the systems I work on. The current setup I use is to have the pushgateway container running adjacent to my application and to push metrics over the TCP loopback interface. As the usage of the pushgateway has scaled up, the overhead and reliability have become worse.

Using unix domain sockets would allow metrics to be collected in a much quicker and reliable way.

 ## In this PR
- Added an ability to set `--web.listen-address` to `unix:/path/to/sock` as a way of specifying that the server should open a listener using "unix" domain sockets.

 ## How this was tested
- I have made patches against prometheus push gateway and made a proof-of-concept that seems to work correctly.