### PR TITLE
Add security attributes to external links to prevent reverse tabnabbing

### DIFF
--- a/web/landing_page.html
+++ b/web/landing_page.html
@@ -36,7 +36,7 @@
         <li><a href="{{if $.RoutePrefix}}{{ $.RoutePrefix }}{{end}}debug/pprof/heap">heap usage (memory)</a>
         <li><a href="{{if $.RoutePrefix}}{{ $.RoutePrefix }}{{end}}debug/pprof/profile?seconds=60">CPU usage (60 second profile)</a>
       </ul>
-      To visualize and share profiles you can upload to <a href="https://pprof.me" target="_blank">pprof.me</a>
+      To visualize and share profiles you can upload to <a href="https://pprof.me" target="_blank" rel="noopener noreferrer">pprof.me</a>
       </div>
     </main>
   </body>


### PR DESCRIPTION
Adding rel="noopener noreferrer" to external links that use target="_blank" to prevent potential reverse tabnabbing attacks. This security enhancement blocks malicious websites opened in new tabs from manipulating the original page context.