### PR TITLE
fix: `MarshalYAML` receivers on `TLSVersion` and `Curve`

### DIFF
--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -483,7 +483,7 @@ func (c *Curve) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 func (c Curve) MarshalYAML() (interface{}, error) {
 	for s, curveid := range curves {
-		if *c == curveid {
+		if c == curveid {
 			return s, nil
 		}
 	}
@@ -514,7 +514,7 @@ func (tv *TLSVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 func (tv TLSVersion) MarshalYAML() (interface{}, error) {
 	for s, v := range tlsVersions {
-		if *tv == v {
+		if tv == v {
 			return s, nil
 		}
 	}

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -481,7 +481,7 @@ func (c *Curve) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return errors.New("unknown curve: " + s)
 }
 
-func (c *Curve) MarshalYAML() (interface{}, error) {
+func (c Curve) MarshalYAML() (interface{}, error) {
 	for s, curveid := range curves {
 		if *c == curveid {
 			return s, nil
@@ -512,7 +512,7 @@ func (tv *TLSVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return errors.New("unknown TLS version: " + s)
 }
 
-func (tv *TLSVersion) MarshalYAML() (interface{}, error) {
+func (tv TLSVersion) MarshalYAML() (interface{}, error) {
 	for s, v := range tlsVersions {
 		if *tv == v {
 			return s, nil

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -42,26 +42,26 @@ var (
 )
 
 type Config struct {
-	TLSConfig         TLSConfig                     `yaml:"tls_server_config"`
-	HTTPConfig        HTTPConfig                    `yaml:"http_server_config"`
-	RateLimiterConfig RateLimiterConfig             `yaml:"rate_limit"`
-	Users             map[string]config_util.Secret `yaml:"basic_auth_users"`
+	TLSConfig         TLSConfig                     `yaml:"tls_server_config,omitempty"`
+	HTTPConfig        HTTPConfig                    `yaml:"http_server_config,omitempty"`
+	RateLimiterConfig RateLimiterConfig             `yaml:"rate_limit,omitempty"`
+	Users             map[string]config_util.Secret `yaml:"basic_auth_users,omitempty"`
 }
 
 type TLSConfig struct {
-	TLSCert                  string             `yaml:"cert"`
-	TLSKey                   config_util.Secret `yaml:"key"`
-	ClientCAsText            string             `yaml:"client_ca"`
-	TLSCertPath              string             `yaml:"cert_file"`
-	TLSKeyPath               string             `yaml:"key_file"`
-	ClientAuth               string             `yaml:"client_auth_type"`
-	ClientCAs                string             `yaml:"client_ca_file"`
-	CipherSuites             []Cipher           `yaml:"cipher_suites"`
-	CurvePreferences         []Curve            `yaml:"curve_preferences"`
-	MinVersion               TLSVersion         `yaml:"min_version"`
-	MaxVersion               TLSVersion         `yaml:"max_version"`
-	PreferServerCipherSuites bool               `yaml:"prefer_server_cipher_suites"`
-	ClientAllowedSans        []string           `yaml:"client_allowed_sans"`
+	TLSCert                  string             `yaml:"cert,omitempty"`
+	TLSKey                   config_util.Secret `yaml:"key,omitempty"`
+	ClientCAsText            string             `yaml:"client_ca,omitempty"`
+	TLSCertPath              string             `yaml:"cert_file,omitempty"`
+	TLSKeyPath               string             `yaml:"key_file,omitempty"`
+	ClientAuth               string             `yaml:"client_auth_type,omitempty"`
+	ClientCAs                string             `yaml:"client_ca_file,omitempty"`
+	CipherSuites             []Cipher           `yaml:"cipher_suites,omitempty"`
+	CurvePreferences         []Curve            `yaml:"curve_preferences,omitempty"`
+	MinVersion               TLSVersion         `yaml:"min_version,omitempty"`
+	MaxVersion               TLSVersion         `yaml:"max_version,omitempty"`
+	PreferServerCipherSuites bool               `yaml:"prefer_server_cipher_suites,omitempty"`
+	ClientAllowedSans        []string           `yaml:"client_allowed_sans,omitempty"`
 }
 
 type FlagConfig struct {

--- a/web/tls_config_test.go
+++ b/web/tls_config_test.go
@@ -27,9 +27,13 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/prometheus/common/config"
+	"go.yaml.in/yaml/v2"
 )
 
 // Helpers for literal FlagConfig
@@ -713,5 +717,128 @@ func TestUsers(t *testing.T) {
 	}
 	for _, testInputs := range testTables {
 		t.Run(testInputs.Name, testInputs.Test)
+	}
+}
+
+func TestConfigGeneration(t *testing.T) {
+	// Secrets to be rendered without any masking
+	config.MarshalSecretValue = true
+
+	testTables := []struct {
+		Name     string
+		Config   Config
+		Expected string
+	}{
+		{
+			Name: "Only basic auth",
+			Config: Config{
+				Users: map[string]config.Secret{
+					"admin": config.Secret("$2y$10$X0h1gDsPszWURQaxFh.zoubFi6DXncSjhoQNJgRrnGs7EsimhC7zG"),
+				},
+			},
+			Expected: `
+basic_auth_users:
+  admin: $2y$10$X0h1gDsPszWURQaxFh.zoubFi6DXncSjhoQNJgRrnGs7EsimhC7zG`,
+		},
+		{
+			Name: "Only TLS",
+			Config: Config{
+				TLSConfig: TLSConfig{
+					TLSCertPath: "cert.pem",
+					TLSKeyPath:  "key.pem",
+					MinVersion:  TLSVersion(tls.VersionTLS12),
+					CurvePreferences: []Curve{
+						Curve(tls.CurveP256),
+						Curve(tls.CurveP521),
+					},
+					CipherSuites: []Cipher{
+						Cipher(tls.TLS_AES_128_GCM_SHA256),
+					},
+					ClientAllowedSans: []string{
+						"example.com",
+						"example.org",
+					},
+				},
+			},
+			Expected: `
+tls_server_config:
+  cert_file: cert.pem
+  key_file: key.pem
+  cipher_suites:
+  - TLS_AES_128_GCM_SHA256
+  curve_preferences:
+  - CurveP256
+  - CurveP521
+  min_version: TLS12
+  client_allowed_sans:
+  - example.com
+  - example.org`,
+		},
+		{
+			Name: "Only HTTP config",
+			Config: Config{
+				HTTPConfig: HTTPConfig{
+					HTTP2: true,
+					Header: map[string]string{
+						"X-Custom-Header": "value",
+					},
+				},
+			},
+			Expected: `
+http_server_config:
+  http2: true
+  headers:
+    X-Custom-Header: value`,
+		},
+		{
+			Name: "Basic auth and TLS",
+			Config: Config{
+				Users: map[string]config.Secret{
+					"admin": config.Secret("$2y$10$X0h1gDsPszWURQaxFh.zoubFi6DXncSjhoQNJgRrnGs7EsimhC7zG"),
+				},
+				TLSConfig: TLSConfig{
+					TLSCertPath: "cert.pem",
+					TLSKeyPath:  "key.pem",
+					MinVersion:  TLSVersion(tls.VersionTLS12),
+					CurvePreferences: []Curve{
+						Curve(tls.CurveP256),
+						Curve(tls.CurveP521),
+					},
+					CipherSuites: []Cipher{
+						Cipher(tls.TLS_AES_128_GCM_SHA256),
+					},
+					ClientAllowedSans: []string{
+						"example.com",
+						"example.org",
+					},
+				},
+			},
+			Expected: `
+tls_server_config:
+  cert_file: cert.pem
+  key_file: key.pem
+  cipher_suites:
+  - TLS_AES_128_GCM_SHA256
+  curve_preferences:
+  - CurveP256
+  - CurveP521
+  min_version: TLS12
+  client_allowed_sans:
+  - example.com
+  - example.org
+basic_auth_users:
+  admin: $2y$10$X0h1gDsPszWURQaxFh.zoubFi6DXncSjhoQNJgRrnGs7EsimhC7zG`,
+		},
+	}
+
+	for _, test := range testTables {
+		yamlConfig, err := yaml.Marshal(&test.Config)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if strings.TrimSpace(test.Expected) != strings.TrimSpace(string(yamlConfig)) {
+			t.Fatalf("Expected config: %s, got config: %s", test.Expected, string(yamlConfig))
+		}
 	}
 }


### PR DESCRIPTION
Currently the `MarshalYAML` receivers are defined on pointers of `TLSVersion` and `Curve` but `TLSConfig` is defined with values of `TLSVersion` and `Curve` in its fields. So, `MarshalYAML` receiver is never called upon. This commit fixes it by changing receivers to non-pointer values which should work on both values and pointers.

Reproducer that shows the behaviour:

```
package main

import (
	"crypto/tls"
	"errors"
	"fmt"

	"github.com/prometheus/exporter-toolkit/web"
	"gopkg.in/yaml.v3"
)

type TLSVersion uint16

var tlsVersions = map[string]TLSVersion{
	"TLS13": (TLSVersion)(tls.VersionTLS13),
	"TLS12": (TLSVersion)(tls.VersionTLS12),
	"TLS11": (TLSVersion)(tls.VersionTLS11),
	"TLS10": (TLSVersion)(tls.VersionTLS10),
}

func (tv *TLSVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
	var s string
	err := unmarshal((*string)(&s))
	if err != nil {
		return err
	}
	if v, ok := tlsVersions[s]; ok {
		*tv = v
		return nil
	}
	return errors.New("unknown TLS version: " + s)
}

// NOTE THAT WE HAVE CHANGED RECEIVER TO NON-POINTER VALUE
func (tv TLSVersion) MarshalYAML() (interface{}, error) {
	for s, v := range tlsVersions {
		if tv == v {
			return s, nil
		}
	}
	return fmt.Sprintf("%v", tv), nil
}

type Curve tls.CurveID

var curves = map[string]Curve{
	"CurveP256": (Curve)(tls.CurveP256),
	"CurveP384": (Curve)(tls.CurveP384),
	"CurveP521": (Curve)(tls.CurveP521),
	"X25519":    (Curve)(tls.X25519),
}

func (c *Curve) UnmarshalYAML(unmarshal func(interface{}) error) error {
	var s string
	err := unmarshal((*string)(&s))
	if err != nil {
		return err
	}
	if curveid, ok := curves[s]; ok {
		*c = curveid
		return nil
	}
	return errors.New("unknown curve: " + s)
}

// NOTE THAT WE HAVE CHANGED RECEIVER TO NON-POINTER VALUE
func (c Curve) MarshalYAML() (interface{}, error) {
	for s, curveid := range curves {
		if c == curveid {
			return s, nil
		}
	}
	return fmt.Sprintf("%v", c), nil
}

type NewConfig struct {
	TLSConfig TLSConfig `yaml:"tls_server_config"`
}

type TLSConfig struct {
	MinVersion       TLSVersion `yaml:"min_version"`
	MaxVersion       TLSVersion `yaml:"max_version"`
	CurvePreferences []Curve    `yaml:"curve_preferences"`
}

func main() {
	actualConfig := web.Config{
		TLSConfig: web.TLSConfig{
			MinVersion:       web.TLSVersion(tls.VersionTLS12),
			MaxVersion:       web.TLSVersion(tls.VersionTLS13),
			CurvePreferences: []web.Curve{web.Curve(tls.CurveP256)},
			CipherSuites:     []web.Cipher{web.Cipher(tls.TLS_AES_128_GCM_SHA256)},
		},
	}

	newConfig := NewConfig{
		TLSConfig: TLSConfig{
			MinVersion:       TLSVersion(tls.VersionTLS12),
			MaxVersion:       TLSVersion(tls.VersionTLS13),
			CurvePreferences: []Curve{Curve(tls.CurveP256)},
		},
	}

	actualConfigYAML, _ := yaml.Marshal(&actualConfig)
	fmt.Println("Actual Config struct: \n", string(actualConfigYAML))

	newConfigYAML, _ := yaml.Marshal(&newConfig)
	fmt.Println("Modified Config struct: \n", string(newConfigYAML))
}

```

This should produce an output as follows:

```
Actual Config struct 
tls_server_config:
    cert: ""
    key: null
    client_ca: ""
    cert_file: ""
    key_file: ""
    client_auth_type: ""
    client_ca_file: ""
    cipher_suites:
        - TLS_AES_128_GCM_SHA256
    curve_preferences:
        - 23
    min_version: 771
    max_version: 772
    prefer_server_cipher_suites: false
    client_allowed_sans: []
http_server_config:
    http2: false
basic_auth_users: {}

Modified Config struct: 
tls_server_config:
    min_version: TLS12
    max_version: TLS13
    curve_preferences:
        - CurveP256
```

With current package's implementation, `yaml.Marshal` produces `uint` for `min_version`, `max_version` and `curve_preferneces`. When changed to receivers of `MarshalYAML` to non-pointer values, marshalled config produces correct output.

This PR fixes the marshall receivers and add unit tests to verify config file generation from structs. `omitempty` has been added to the config fields to avoid producing "zero" values when config file is being generated from Go structs. When fields are not set, the library use "sane" defaults which can be leveraged by client libraries.