### PR TITLE
Trim leading slash on Action button URL

### DIFF
--- a/web/landing_page.go
+++ b/web/landing_page.go
@@ -77,6 +77,8 @@ var (
 func NewLandingPage(c LandingConfig) (*LandingPageHandler, error) {
 	var buf bytes.Buffer
 
+	c.Form.Action = strings.TrimPrefix(c.Form.Action, "/")
+
 	length := 0
 	for _, input := range c.Form.Inputs {
 		inputLength := len(input.Label)


### PR DESCRIPTION
Fix for #296 
Trim off a leading slash on the Action button URL if present