### PR TITLE
chore: Fix some linting issues

### DIFF
--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -254,11 +254,11 @@ func ConfigToTLSConfig(c *TLSConfig) (*tls.Config, error) {
 	case "", "NoClientCert":
 		cfg.ClientAuth = tls.NoClientCert
 	default:
-		return nil, errors.New("Invalid ClientAuth: " + c.ClientAuth)
+		return nil, errors.New("invalid ClientAuth: " + c.ClientAuth)
 	}
 
 	if (c.ClientCAs != "" || c.ClientCAsText != "") && cfg.ClientAuth == tls.NoClientCert {
-		return nil, errors.New("Client CA's have been configured without a Client Auth Policy")
+		return nil, errors.New("client CA's have been configured without a Client Auth Policy")
 	}
 
 	return cfg, nil
@@ -269,7 +269,6 @@ func ConfigToTLSConfig(c *TLSConfig) (*tls.Config, error) {
 func ServeMultiple(listeners []net.Listener, server *http.Server, flags *FlagConfig, logger *slog.Logger) error {
 	errs := new(errgroup.Group)
 	for _, l := range listeners {
-		l := l
 		errs.Go(func() error {
 			return Serve(l, server, flags, logger)
 		})
@@ -428,7 +427,7 @@ type Cipher uint16
 
 func (c *Cipher) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
-	err := unmarshal((*string)(&s))
+	err := unmarshal(&s)
 	if err != nil {
 		return err
 	}
@@ -456,7 +455,7 @@ var curves = map[string]Curve{
 
 func (c *Curve) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
-	err := unmarshal((*string)(&s))
+	err := unmarshal(&s)
 	if err != nil {
 		return err
 	}
@@ -487,7 +486,7 @@ var tlsVersions = map[string]TLSVersion{
 
 func (tv *TLSVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
-	err := unmarshal((*string)(&s))
+	err := unmarshal(&s)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
web/tls_config.go:261:15       staticcheck  ST1005: error strings should not be capitalized
web/tls_config.go:431:28       unconvert    unnecessary conversion
web/tls_config.go:459:28       unconvert    unnecessary conversion
web/tls_config.go:490:28       unconvert    unnecessary conversion
web/tls_config.go:272:3        copyloopvar  The copy of the 'for' variable "l" can be deleted (Go 1.22+)