### PR TITLE
chore: Enable modernize linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ formatters:
 linters:
   enable:
     - misspell
+    - modernize
     - revive
   exclusions:
     generated: strict

--- a/web/cache.go
+++ b/web/cache.go
@@ -63,10 +63,7 @@ func (c *cache) makeRoom() {
 	// the cache is on a long tail, we can save a lot of CPU
 	// time by doing a whole bunch of deletions now and then
 	// we won't have to do them again for a while.
-	numToDelete := len(c.cache) / 10
-	if numToDelete < 1 {
-		numToDelete = 1
-	}
+	numToDelete := max(len(c.cache)/10, 1)
 	for deleted := 0; deleted <= numToDelete; deleted++ {
 		// Go maps are "nondeterministic" not actually random,
 		// so although we could just chop off the "front" of the

--- a/web/cache_test.go
+++ b/web/cache_test.go
@@ -23,7 +23,7 @@ import (
 func TestCacheSize(t *testing.T) {
 	cache := newCache()
 	expectedSize := 0
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		cache.set(fmt.Sprintf("foo%d", i), true)
 		expectedSize++
 		if expectedSize > 100 {

--- a/web/handler_test.go
+++ b/web/handler_test.go
@@ -75,18 +75,15 @@ func TestBasicAuthCache(t *testing.T) {
 		start = make(chan struct{})
 		wg    sync.WaitGroup
 	)
-	wg.Add(300)
-	for i := 0; i < 150; i++ {
-		go func() {
+	for range 150 {
+		wg.Go(func() {
 			<-start
 			login("alice", "alice123", 200)
-			wg.Done()
-		}()
-		go func() {
+		})
+		wg.Go(func() {
 			<-start
 			login("alice", "alice1234", 401)
-			wg.Done()
-		}()
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/web/landing_page.go
+++ b/web/landing_page.go
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 //go:build !genassets
-// +build !genassets
 
 //go:generate go run -tags genassets gen_assets.go
 

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -97,10 +98,8 @@ func (t *TLSConfig) VerifyPeerCertificate(rawCerts [][]byte, _ [][]*x509.Certifi
 	}
 
 	for _, sanValue := range sanValues {
-		for _, allowedSan := range t.ClientAllowedSans {
-			if sanValue == allowedSan {
-				return nil
-			}
+		if slices.Contains(t.ClientAllowedSans, sanValue) {
+			return nil
 		}
 	}
 
@@ -440,7 +439,7 @@ func Validate(tlsConfigPath string) error {
 
 type Cipher uint16
 
-func (c *Cipher) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Cipher) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	err := unmarshal(&s)
 	if err != nil {
@@ -455,7 +454,7 @@ func (c *Cipher) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return errors.New("unknown cipher: " + s)
 }
 
-func (c Cipher) MarshalYAML() (interface{}, error) {
+func (c Cipher) MarshalYAML() (any, error) {
 	return tls.CipherSuiteName((uint16)(c)), nil
 }
 
@@ -468,7 +467,7 @@ var curves = map[string]Curve{
 	"X25519":    (Curve)(tls.X25519),
 }
 
-func (c *Curve) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (c *Curve) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	err := unmarshal(&s)
 	if err != nil {
@@ -481,7 +480,7 @@ func (c *Curve) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return errors.New("unknown curve: " + s)
 }
 
-func (c *Curve) MarshalYAML() (interface{}, error) {
+func (c *Curve) MarshalYAML() (any, error) {
 	for s, curveid := range curves {
 		if *c == curveid {
 			return s, nil
@@ -499,7 +498,7 @@ var tlsVersions = map[string]TLSVersion{
 	"TLS10": (TLSVersion)(tls.VersionTLS10),
 }
 
-func (tv *TLSVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (tv *TLSVersion) UnmarshalYAML(unmarshal func(any) error) error {
 	var s string
 	err := unmarshal(&s)
 	if err != nil {
@@ -512,7 +511,7 @@ func (tv *TLSVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return errors.New("unknown TLS version: " + s)
 }
 
-func (tv *TLSVersion) MarshalYAML() (interface{}, error) {
+func (tv *TLSVersion) MarshalYAML() (any, error) {
 	for s, v := range tlsVersions {
 		if *tv == v {
 			return s, nil

--- a/web/tls_config_test.go
+++ b/web/tls_config_test.go
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build go1.14
-// +build go1.14
-
 package web
 
 import (


### PR DESCRIPTION
Enable `modernize` linter.
Run `go fix ./... && golangci-lint run --fix`.
Do a few trivial changes.