### PR TITLE
web: add X25519MLKEM768 post-quantum curve to TLS config

### DIFF
--- a/docs/web-configuration.md
+++ b/docs/web-configuration.md
@@ -86,7 +86,7 @@ tls_server_config:
   # the order of elements in cipher_suites, is used.
   [ prefer_server_cipher_suites: <bool> | default = true ]
 
-  # Elliptic curves that will be used in an ECDHE handshake, in preference
+  # Elliptic curves and key exchange mechanisms that will be used in a TLS handshake, in preference
   # order. Available curves are documented in the go documentation:
   # https://golang.org/pkg/crypto/tls/#CurveID
   [ curve_preferences:

--- a/web/testdata/web_config_noAuth_allCurves.good.yml
+++ b/web/testdata/web_config_noAuth_allCurves.good.yml
@@ -7,3 +7,4 @@ tls_server_config:
     - CurveP384
     - CurveP521
     - X25519
+    - X25519MLKEM768

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -480,10 +480,11 @@ func (c Cipher) MarshalYAML() (any, error) {
 type Curve tls.CurveID
 
 var curves = map[string]Curve{
-	"CurveP256": (Curve)(tls.CurveP256),
-	"CurveP384": (Curve)(tls.CurveP384),
-	"CurveP521": (Curve)(tls.CurveP521),
-	"X25519":    (Curve)(tls.X25519),
+	"CurveP256":      (Curve)(tls.CurveP256),
+	"CurveP384":      (Curve)(tls.CurveP384),
+	"CurveP521":      (Curve)(tls.CurveP521),
+	"X25519":         (Curve)(tls.X25519),
+	"X25519MLKEM768": (Curve)(tls.X25519MLKEM768),
 }
 
 func (c *Curve) UnmarshalYAML(unmarshal func(any) error) error {


### PR DESCRIPTION
## Summary

Add the X25519MLKEM768 hybrid post-quantum key exchange to the supported `curve_preferences` map in `web-config.yaml`.

## Motivation

X25519MLKEM768 (CurveID 4588) combines X25519 with ML-KEM-768 (FIPS 203). Go 1.24+ includes it in the default TLS 1.3 key exchange preferences when `CurvePreferences` is nil. However, users who explicitly set `curve_preferences` in their web config to control which key exchanges are offered cannot currently include `X25519MLKEM768`, which effectively disables post-quantum key exchange for those deployments.

This is particularly relevant for projects like Prometheus exporters running in environments with post-quantum cryptography mandates (e.g., OpenShift, which enforces centralized TLS security profiles).

## Changes

- `web/tls_config.go`: Add `X25519MLKEM768` to the `curves` map
- `web/testdata/web_config_noAuth_allCurves.good.yml`: Add to test fixture
- `docs/web-configuration.md`: Update description to cover non-ECDHE key exchanges

## Notes

- Go 1.26 will add `SecP256r1MLKEM768` and `SecP384r1MLKEM1024`. Those can be added in a follow-up when this module bumps its Go version requirement.
- `X25519MLKEM768` is TLS 1.3 only. If configured with `min_version: TLS12`, Go will silently skip it during TLS 1.2 handshakes — no error, it just won't be negotiated. This is the same behavior as the existing curves.

Signed-off-by: Ali Syed <alsyed@redhat.com>