### PR TITLE
lint: enable govet (all) and a set of correctness linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,13 @@ linters:
     - misspell
     - modernize
     - revive
+    # Correctness linters (low-noise, no findings on the current tree).
+    - copyloopvar
+    - durationcheck
+    - gocritic
+    - makezero
+    - unconvert
+    - wastedassign
   exclusions:
     generated: strict
     presets:
@@ -23,6 +30,13 @@ linters:
       exclude-functions:
         # Used in HTTP handlers, any error is handled by the server itself.
         - (net/http.ResponseWriter).Write
+    govet:
+      enable-all: true
+      disable:
+        # Struct field ordering is not worth the churn/readability cost.
+        - fieldalignment
+        # err shadowing is idiomatic and used throughout the codebase.
+        - shadow
     revive:
       rules:
         # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -106,7 +106,7 @@ func (t *TLSConfig) VerifyPeerCertificate(rawCerts [][]byte, _ [][]*x509.Certifi
 	}
 
 	// Build up a slice of strings with all Subject Alternate Name values
-	sanValues := append(cert.DNSNames, cert.EmailAddresses...)
+	sanValues := slices.Concat(cert.DNSNames, cert.EmailAddresses)
 
 	for _, ip := range cert.IPAddresses {
 		sanValues = append(sanValues, ip.String())


### PR DESCRIPTION
Hi 👋 — over in blackbox_exporter we recently landed prometheus/blackbox_exporter#1631 to enable a few more linters, and it occurred to us the same low-noise additions might help here too, so we thought we would try to help by proposing them for exporter-toolkit as well.

### Why

The current `.golangci.yml` runs `misspell`, `modernize`, `revive` (plus the golangci-lint v2 defaults). `govet` runs only its default analyzer subset, so a few correctness checks (`composites`, `unreachable`, `copylocks`, etc.) are not enforced in CI.

### What

Enable `govet` with `enable-all` (minus `fieldalignment`, which is churn-heavy, and `shadow`, which is idiomatic and used throughout this codebase) plus a curated, low-noise correctness set: `copyloopvar`, `durationcheck`, `gocritic`, `makezero`, `unconvert`, `wastedassign`.

These surfaced exactly one finding — `gocritic`'s `appendAssign` on `append(cert.DNSNames, cert.EmailAddresses...)` in `VerifyPeerCertificate`, where appending to `cert.DNSNames` can mutate its backing array. That is fixed in the first commit with `slices.Concat`; after it, `golangci-lint run ./...` is clean and `go build` / `go test ./...` pass.

No golangci-lint version bump is needed — every linter above is available in the pinned version (`Makefile.common` untouched).

Happy to trim or extend the set to your preference. As a follow-up we would also like to propose adding `ReadHeaderTimeout` to the `http.Server` in `bootstrap/` (a Slowloris hardening, matching prometheus/blackbox_exporter#1626).

🤖 Generated with [Claude Code](https://claude.com/claude-code)