### PR TITLE
bootstrap: set ReadHeaderTimeout on the HTTP server

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/common/promslog"
@@ -42,6 +43,9 @@ var (
 	// errNegativeMaxRequests is returned when max requests is configured below zero.
 	errNegativeMaxRequests = errors.New("web max requests must be greater than or equal to zero")
 )
+
+// defaultReadHeaderTimeout applies when Config.ReadHeaderTimeout is left unset.
+const defaultReadHeaderTimeout = time.Minute
 
 // MetricsHandlerFactory builds an exporter-specific metrics handler after the
 // common toolkit flags have been parsed.
@@ -82,6 +86,9 @@ type Config struct {
 	MetricsHandler http.Handler
 	// MetricsHandlerFactory builds the metrics handler after flags are parsed.
 	MetricsHandlerFactory MetricsHandlerFactory
+	// ReadHeaderTimeout bounds request-header reads, mitigating Slowloris
+	// (gosec G112). Defaults to one minute when zero.
+	ReadHeaderTimeout time.Duration
 }
 
 // Runner manages generic exporter startup around flag parsing, landing page
@@ -250,7 +257,15 @@ func (t *Runner) newServer(metricsHandler http.Handler) (*http.Server, error) {
 		mux.Handle("/", landingPage)
 	}
 
-	return &http.Server{Handler: mux}, nil
+	readHeaderTimeout := defaultReadHeaderTimeout
+	if t.provided.ReadHeaderTimeout > 0 {
+		readHeaderTimeout = t.provided.ReadHeaderTimeout
+	}
+
+	return &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+	}, nil
 }
 
 func (t *Runner) defaultLandingConfig() web.LandingConfig {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/common/promslog"
@@ -41,6 +42,9 @@ var (
 	// errNegativeMaxRequests is returned when max requests is configured below zero.
 	errNegativeMaxRequests = errors.New("web max requests must be greater than or equal to zero")
 )
+
+// defaultReadHeaderTimeout applies when Config.ReadHeaderTimeout is left unset.
+const defaultReadHeaderTimeout = time.Minute
 
 // MetricsHandlerFactory builds an exporter-specific metrics handler after the
 // common toolkit flags have been parsed.
@@ -81,6 +85,9 @@ type Config struct {
 	MetricsHandler http.Handler
 	// MetricsHandlerFactory builds the metrics handler after flags are parsed.
 	MetricsHandlerFactory MetricsHandlerFactory
+	// ReadHeaderTimeout bounds request-header reads, mitigating Slowloris
+	// (gosec G112). Non-positive values select the one-minute default.
+	ReadHeaderTimeout time.Duration
 }
 
 // Runner manages generic exporter startup around flag parsing, landing page
@@ -249,7 +256,15 @@ func (t *Runner) newServer(metricsHandler http.Handler) (*http.Server, error) {
 		mux.Handle("/", landingPage)
 	}
 
-	return &http.Server{Handler: mux}, nil
+	readHeaderTimeout := defaultReadHeaderTimeout
+	if t.provided.ReadHeaderTimeout > 0 {
+		readHeaderTimeout = t.provided.ReadHeaderTimeout
+	}
+
+	return &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
+	}, nil
 }
 
 func (t *Runner) defaultLandingConfig() web.LandingConfig {

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -14,10 +14,12 @@
 package bootstrap
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/common/promslog"
@@ -127,5 +129,119 @@ func TestNewServerRegistersMetricsAndLandingPage(t *testing.T) {
 	}
 	if body := landingRec.Body.String(); body == "" || !strings.Contains(body, "Metrics") || !strings.Contains(body, "test description") {
 		t.Fatalf("unexpected landing body: %q", body)
+	}
+}
+
+// TestNewServerReadHeaderTimeout checks newServer maps Config.ReadHeaderTimeout
+// onto the server, defaulting to one minute when unset.
+func TestNewServerReadHeaderTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{name: "unset defaults", configured: 0, want: defaultReadHeaderTimeout},
+		{name: "explicit default", configured: time.Minute, want: time.Minute},
+		{name: "sub-second value", configured: 250 * time.Millisecond, want: 250 * time.Millisecond},
+		{name: "smallest positive value", configured: time.Nanosecond, want: time.Nanosecond},
+		{name: "large value", configured: time.Hour, want: time.Hour},
+		{name: "negative defaults", configured: -1, want: defaultReadHeaderTimeout},
+		{name: "large negative defaults", configured: -time.Hour, want: defaultReadHeaderTimeout},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tk := New(Config{
+				App:               kingpin.New("test", ""),
+				DefaultAddress:    ":9100",
+				Logger:            promslog.NewNopLogger(),
+				ReadHeaderTimeout: tc.configured,
+				MetricsHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}),
+			})
+			if err := tk.parse([]string{"--web.listen-address=:0"}); err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			handler, err := tk.resolveMetricsHandler()
+			if err != nil {
+				t.Fatalf("unexpected handler resolution error: %v", err)
+			}
+			server, err := tk.newServer(handler)
+			if err != nil {
+				t.Fatalf("unexpected server creation error: %v", err)
+			}
+			if server.ReadHeaderTimeout != tc.want {
+				t.Fatalf("unexpected ReadHeaderTimeout: got %v, want %v", server.ReadHeaderTimeout, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewServerReadHeaderTimeoutClosesStalledConnection checks the timeout is
+// effective end-to-end: a connection with incomplete headers is closed while a
+// well-formed request succeeds.
+func TestNewServerReadHeaderTimeoutClosesStalledConnection(t *testing.T) {
+	const readHeaderTimeout = 250 * time.Millisecond
+
+	tk := New(Config{
+		App:               kingpin.New("test", ""),
+		Name:              "test_exporter",
+		Description:       "test description",
+		DefaultAddress:    ":9100",
+		Logger:            promslog.NewNopLogger(),
+		ReadHeaderTimeout: readHeaderTimeout,
+		MetricsHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	})
+	if err := tk.parse([]string{"--web.listen-address=:0"}); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	handler, err := tk.resolveMetricsHandler()
+	if err != nil {
+		t.Fatalf("unexpected handler resolution error: %v", err)
+	}
+	server, err := tk.newServer(handler)
+	if err != nil {
+		t.Fatalf("unexpected server creation error: %v", err)
+	}
+	if server.ReadHeaderTimeout != readHeaderTimeout {
+		t.Fatalf("unexpected ReadHeaderTimeout: got %v, want %v", server.ReadHeaderTimeout, readHeaderTimeout)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() { _ = server.Serve(ln) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	// A well-formed request still succeeds.
+	resp, err := http.Get("http://" + ln.Addr().String() + "/metrics")
+	if err != nil {
+		t.Fatalf("well-formed request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// Start request headers but never terminate them (no final CRLF).
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if _, err := conn.Write([]byte("GET /metrics HTTP/1.1\r\nHost: localhost\r\n")); err != nil {
+		t.Fatalf("write partial request: %v", err)
+	}
+
+	// Read in a goroutine so the test never hangs if the server keeps it open.
+	done := make(chan struct{})
+	go func() {
+		_, _ = conn.Read(make([]byte, 1)) // unblocks on server-side close
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not close the stalled connection within 5s; ReadHeaderTimeout not effective")
 	}
 }


### PR DESCRIPTION
Hi again 👋 — a small hardening follow-up, as mentioned in #420.

### Why

`Runner.newServer` in `bootstrap/` returns `&http.Server{Handler: mux}` with `ReadHeaderTimeout` unset, so request-header reads are unbounded — a Slowloris-style connection-exhaustion vector (gosec G112). Because the `web` package does not set server timeouts either, every bootstrap-based exporter inherits the gap.

This is the toolkit-side counterpart to prometheus/blackbox_exporter#1626, which set the same timeout on the caller side. Fixing it here addresses it once for all toolkit users.

### What

Add a `ReadHeaderTimeout time.Duration` field to `bootstrap.Config`, defaulting to one minute when unset. It bounds only header reading, not the metrics handler, so it never affects legitimate scrapes (which can run for the full scrape timeout), and — like every other `Config` field — downstream exporters can tune it to their own needs.

Table-driven tests assert the field maps onto the server (default when unset, configured value otherwise, non-positive treated as unset); a behavioral test confirms the server closes a connection whose headers never complete while a well-formed request still succeeds.

Thanks to @nicolastakashi for the excellent suggestion to make this a `Config` field rather than a package-level var — it's a much better fit for how the rest of `Config` is configured (plain struct fields, not functional options) and lets downstream exporters tune it too.

`go build`, `go vet`, `go test ./...` (incl. `-race`) pass; gosec G112 clears. Happy to adjust the value if a different bound is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
