### PR TITLE
web: add TLSConfig.IsEnabled() method

### DIFF
--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -90,6 +90,18 @@ func (c *FlagConfig) checkFlags() error {
 	return nil
 }
 
+// IsEnabled reports whether the TLSConfig configures TLS, i.e. whether at least
+// one TLS-related field is set. It does not validate that the configuration is
+// complete or that the referenced files exist; use ConfigToTLSConfig for that.
+// This is useful for callers that need to know whether the server will serve
+// HTTPS, for example to infer the scheme of an external URL.
+func (t *TLSConfig) IsEnabled() bool {
+	return t.TLSCertPath != "" || t.TLSCert != "" ||
+		t.TLSKeyPath != "" || t.TLSKey != "" ||
+		t.ClientCAs != "" || t.ClientCAsText != "" ||
+		t.ClientAuth != ""
+}
+
 // SetDirectory joins any relative file paths with dir.
 func (t *TLSConfig) SetDirectory(dir string) {
 	t.TLSCertPath = config_util.JoinDir(dir, t.TLSCertPath)
@@ -165,10 +177,7 @@ func getTLSConfig(configPath string) (*tls.Config, error) {
 }
 
 func validateTLSPaths(c *TLSConfig) error {
-	if c.TLSCertPath == "" && c.TLSCert == "" &&
-		c.TLSKeyPath == "" && c.TLSKey == "" &&
-		c.ClientCAs == "" && c.ClientCAsText == "" &&
-		c.ClientAuth == "" {
+	if !c.IsEnabled() {
 		return errNoTLSConfig
 	}
 

--- a/web/tls_config_test.go
+++ b/web/tls_config_test.go
@@ -712,3 +712,48 @@ func TestUsers(t *testing.T) {
 		t.Run(testInputs.Name, testInputs.Test)
 	}
 }
+
+func TestTLSConfigIsEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		config   TLSConfig
+		expected bool
+	}{
+		{
+			name:     "empty config",
+			config:   TLSConfig{},
+			expected: false,
+		},
+		{
+			name:     "only non-enabling fields set",
+			config:   TLSConfig{MinVersion: tls.VersionTLS12, PreferServerCipherSuites: true},
+			expected: false,
+		},
+		{
+			name:     "cert_file and key_file set",
+			config:   TLSConfig{TLSCertPath: "server.crt", TLSKeyPath: "server.key"},
+			expected: true,
+		},
+		{
+			name:     "inline cert and key set",
+			config:   TLSConfig{TLSCert: "cert", TLSKey: "key"},
+			expected: true,
+		},
+		{
+			name:     "only client CA file set",
+			config:   TLSConfig{ClientCAs: "client_ca.crt"},
+			expected: true,
+		},
+		{
+			name:     "only client auth type set",
+			config:   TLSConfig{ClientAuth: "RequireAndVerifyClientCert"},
+			expected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.config.IsEnabled(); got != tc.expected {
+				t.Errorf("IsEnabled() = %v, expected %v", got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Made with LLM for https://github.com/prometheus/prometheus/pull/19241

## What

Adds an exported `IsEnabled()` method on `web.TLSConfig` that reports whether TLS is configured, i.e. whether at least one TLS-related field (`cert`/`cert_file`, `key`/`key_file`, `client_ca`/`client_ca_file`, `client_auth_type`) is set.

The internal `validateTLSPaths` already performs exactly this check to decide whether to return `errNoTLSConfig`; it is refactored to call the new method, so there is no behavioural change and the single source of truth stays inside the package.

## Why

Callers sometimes need to know whether the server will serve HTTPS without going through the full `ConfigToTLSConfig` path, which:

- returns the unexported `errNoTLSConfig` sentinel, so callers can't distinguish "no TLS configured" from "TLS misconfigured" via the public API; and
- eagerly reads the certificate/key files from disk, which fails when the files don't exist yet — undesirable for callers that only want to know the intended scheme.

Concretely, Prometheus infers the scheme of its `--web.external-url` from the web config file. Today it has to reimplement this check with a light YAML unmarshal and a presence test for the `tls_server_config` key (see prometheus/prometheus#19241, fixing prometheus/prometheus#17236). A presence test is also subtly wrong: an empty `tls_server_config:` section makes the server serve plain HTTP, but the key is present. Exposing `IsEnabled()` lets downstream reuse the toolkit's exact semantics instead.

## Testing

- New table-driven `TestTLSConfigIsEnabled` covering empty config, non-enabling fields only, and each enabling field.
- `go test ./web/`, `go vet ./web/`, `gofmt`, and `golangci-lint run ./web/` all clean.