### PR TITLE
bootstrap: allow exporters to add routes

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -41,9 +41,10 @@ var (
 	errEmptyMetricsPath = errors.New("metrics path must not be empty")
 	// errNegativeMaxRequests is returned when max requests is configured below zero.
 	errNegativeMaxRequests = errors.New("web max requests must be greater than or equal to zero")
-	// errProtectedRoutePattern is returned when a caller-registered route
-	// conflicts with a path bootstrap manages itself.
-	errProtectedRoutePattern = errors.New("route pattern is reserved by bootstrap")
+	// errReservedMetricsPath is returned when a caller-registered route
+	// conflicts with --web.telemetry-path. The root path may be overridden
+	// by a caller-registered route, but the metrics path may not.
+	errReservedMetricsPath = errors.New("route pattern is reserved for the metrics handler")
 )
 
 // MetricsHandlerFactory builds an exporter-specific metrics handler after the
@@ -263,17 +264,20 @@ func (t *Runner) newServer(metricsHandler http.Handler) (*http.Server, error) {
 	metricsPath := t.MetricsPath
 	mux.Handle(metricsPath, metricsHandler)
 
+	rootOverridden := false
 	if t.bootstrap != nil {
-		protected := map[string]bool{metricsPath: true, "/": true}
 		for _, r := range t.bootstrap.routes {
-			if protected[r.pattern] {
-				return nil, fmt.Errorf("%w: %q", errProtectedRoutePattern, r.pattern)
+			if r.pattern == metricsPath {
+				return nil, fmt.Errorf("%w: %q", errReservedMetricsPath, r.pattern)
+			}
+			if r.pattern == "/" {
+				rootOverridden = true
 			}
 			mux.Handle(r.pattern, r.handler)
 		}
 	}
 
-	if metricsPath != "/" {
+	if metricsPath != "/" && !rootOverridden {
 		landingConfig := t.LandingConfig
 		landingConfig.Links = append(landingConfig.Links, web.LandingLinks{
 			Address: metricsPath,

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -92,9 +92,6 @@ type Config struct {
 	Description string
 	// DefaultAddress is the default value for --web.listen-address.
 	DefaultAddress string
-	// MetricsPathEnvar is an optional environment variable that overrides the
-	// default value of --web.telemetry-path.
-	MetricsPathEnvar string
 	// Logger is the logger to use. When nil, toolkit configures promslog flags
 	// and builds a logger during Parse.
 	Logger *slog.Logger
@@ -142,17 +139,12 @@ func addFlags(a *kingpin.Application, defaultAddress string) *web.FlagConfig {
 	return kingpinflag.AddFlags(a, defaultAddress)
 }
 
-// metricsPathFlag registers the metrics path flag, optionally backed by an
-// exporter-specific environment variable.
-func metricsPathFlag(a *kingpin.Application, envar string) *string {
-	f := a.Flag(
+// metricsPathFlag registers the metrics path flag.
+func metricsPathFlag(a *kingpin.Application) *string {
+	return a.Flag(
 		"web.telemetry-path",
 		"Path under which to expose metrics.",
-	).Default("/metrics")
-	if envar != "" {
-		f = f.Envar(envar)
-	}
-	return f.String()
+	).Default("/metrics").String()
 }
 
 // New creates a generic exporter bootstrap instance.
@@ -170,7 +162,7 @@ func New(c Config) *Runner {
 		MetricsHandler:        c.MetricsHandler,
 		MetricsHandlerFactory: c.MetricsHandlerFactory,
 		FlagConfig:            addFlags(app, c.DefaultAddress),
-		metricsPath:           metricsPathFlag(app, c.MetricsPathEnvar),
+		metricsPath:           metricsPathFlag(app),
 		disableExporterMetrics: app.Flag(
 			"web.disable-exporter-metrics",
 			"Exclude metrics about the exporter itself (promhttp_*, process_*, go_*).",

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -59,6 +59,26 @@ type Bootstrap struct {
 	DisableExporterMetrics bool
 	// MaxRequests is the parsed value of --web.max-requests.
 	MaxRequests int
+
+	routes []route
+}
+
+// route is an additional handler registered next to the metrics endpoint.
+type route struct {
+	pattern string
+	handler http.Handler
+}
+
+// Handle registers an additional handler on the exporter mux. Handlers
+// registered from a MetricsHandlerFactory are served alongside the metrics
+// endpoint and the landing page.
+func (b *Bootstrap) Handle(pattern string, handler http.Handler) {
+	b.routes = append(b.routes, route{pattern: pattern, handler: handler})
+}
+
+// HandleFunc registers an additional handler function on the exporter mux.
+func (b *Bootstrap) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	b.Handle(pattern, http.HandlerFunc(handler))
 }
 
 // Config defines the generic exporter bootstrap inputs.
@@ -72,6 +92,9 @@ type Config struct {
 	Description string
 	// DefaultAddress is the default value for --web.listen-address.
 	DefaultAddress string
+	// MetricsPathEnvar is an optional environment variable that overrides the
+	// default value of --web.telemetry-path.
+	MetricsPathEnvar string
 	// Logger is the logger to use. When nil, toolkit configures promslog flags
 	// and builds a logger during Parse.
 	Logger *slog.Logger
@@ -110,11 +133,26 @@ type Runner struct {
 	MetricsHandler http.Handler
 	// MetricsHandlerFactory is the configured deferred metrics handler builder.
 	MetricsHandlerFactory MetricsHandlerFactory
+
+	bootstrap *Bootstrap
 }
 
 // addFlags adds the common exporter web flags to a Kingpin application.
 func addFlags(a *kingpin.Application, defaultAddress string) *web.FlagConfig {
 	return kingpinflag.AddFlags(a, defaultAddress)
+}
+
+// metricsPathFlag registers the metrics path flag, optionally backed by an
+// exporter-specific environment variable.
+func metricsPathFlag(a *kingpin.Application, envar string) *string {
+	f := a.Flag(
+		"web.telemetry-path",
+		"Path under which to expose metrics.",
+	).Default("/metrics")
+	if envar != "" {
+		f = f.Envar(envar)
+	}
+	return f.String()
 }
 
 // New creates a generic exporter bootstrap instance.
@@ -132,10 +170,7 @@ func New(c Config) *Runner {
 		MetricsHandler:        c.MetricsHandler,
 		MetricsHandlerFactory: c.MetricsHandlerFactory,
 		FlagConfig:            addFlags(app, c.DefaultAddress),
-		metricsPath: app.Flag(
-			"web.telemetry-path",
-			"Path under which to expose metrics.",
-		).Default("/metrics").String(),
+		metricsPath:           metricsPathFlag(app, c.MetricsPathEnvar),
 		disableExporterMetrics: app.Flag(
 			"web.disable-exporter-metrics",
 			"Exclude metrics about the exporter itself (promhttp_*, process_*, go_*).",
@@ -220,13 +255,14 @@ func (t *Runner) resolveMetricsHandler() (http.Handler, error) {
 		return nil, errMultipleMetricsSource
 	}
 	if t.MetricsHandlerFactory != nil {
-		return t.MetricsHandlerFactory(&Bootstrap{
+		t.bootstrap = &Bootstrap{
 			Logger:                 t.Logger,
 			MetricsPath:            t.MetricsPath,
 			FlagConfig:             t.FlagConfig,
 			DisableExporterMetrics: t.DisableExporterMetrics,
 			MaxRequests:            t.MaxRequests,
-		})
+		}
+		return t.MetricsHandlerFactory(t.bootstrap)
 	}
 	return t.MetricsHandler, nil
 }
@@ -235,6 +271,12 @@ func (t *Runner) newServer(metricsHandler http.Handler) (*http.Server, error) {
 	mux := http.NewServeMux()
 	metricsPath := t.MetricsPath
 	mux.Handle(metricsPath, metricsHandler)
+
+	if t.bootstrap != nil {
+		for _, r := range t.bootstrap.routes {
+			mux.Handle(r.pattern, r.handler)
+		}
+	}
 
 	if metricsPath != "/" {
 		landingConfig := t.LandingConfig

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -139,14 +139,6 @@ func addFlags(a *kingpin.Application, defaultAddress string) *web.FlagConfig {
 	return kingpinflag.AddFlags(a, defaultAddress)
 }
 
-// metricsPathFlag registers the metrics path flag.
-func metricsPathFlag(a *kingpin.Application) *string {
-	return a.Flag(
-		"web.telemetry-path",
-		"Path under which to expose metrics.",
-	).Default("/metrics").String()
-}
-
 // New creates a generic exporter bootstrap instance.
 func New(c Config) *Runner {
 	app := c.App
@@ -162,7 +154,10 @@ func New(c Config) *Runner {
 		MetricsHandler:        c.MetricsHandler,
 		MetricsHandlerFactory: c.MetricsHandlerFactory,
 		FlagConfig:            addFlags(app, c.DefaultAddress),
-		metricsPath:           metricsPathFlag(app),
+		metricsPath: app.Flag(
+			"web.telemetry-path",
+			"Path under which to expose metrics.",
+		).Default("/metrics").String(),
 		disableExporterMetrics: app.Flag(
 			"web.disable-exporter-metrics",
 			"Exclude metrics about the exporter itself (promhttp_*, process_*, go_*).",

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -18,6 +18,7 @@ package bootstrap
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -40,6 +41,9 @@ var (
 	errEmptyMetricsPath = errors.New("metrics path must not be empty")
 	// errNegativeMaxRequests is returned when max requests is configured below zero.
 	errNegativeMaxRequests = errors.New("web max requests must be greater than or equal to zero")
+	// errProtectedRoutePattern is returned when a caller-registered route
+	// conflicts with a path bootstrap manages itself.
+	errProtectedRoutePattern = errors.New("route pattern is reserved by bootstrap")
 )
 
 // MetricsHandlerFactory builds an exporter-specific metrics handler after the
@@ -260,7 +264,11 @@ func (t *Runner) newServer(metricsHandler http.Handler) (*http.Server, error) {
 	mux.Handle(metricsPath, metricsHandler)
 
 	if t.bootstrap != nil {
+		protected := map[string]bool{metricsPath: true, "/": true}
 		for _, r := range t.bootstrap.routes {
+			if protected[r.pattern] {
+				return nil, fmt.Errorf("%w: %q", errProtectedRoutePattern, r.pattern)
+			}
 			mux.Handle(r.pattern, r.handler)
 		}
 	}

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -14,6 +14,7 @@
 package bootstrap
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -165,5 +166,40 @@ func TestNewServerRegistersFactoryRoutes(t *testing.T) {
 	}
 	if body := rec.Body.String(); body != "probe body" {
 		t.Fatalf("unexpected probe body: got %q", body)
+	}
+}
+
+func TestNewServerRejectsProtectedRoutePatterns(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "metrics path", pattern: "/metrics"},
+		{name: "root path", pattern: "/"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tk := New(Config{
+				App:            kingpin.New("test", ""),
+				DefaultAddress: ":9100",
+				Logger:         promslog.NewNopLogger(),
+				MetricsHandlerFactory: func(b *Bootstrap) (http.Handler, error) {
+					b.HandleFunc(tc.pattern, func(http.ResponseWriter, *http.Request) {})
+					return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), nil
+				},
+			})
+
+			if err := tk.parse([]string{"--web.listen-address=:9100"}); err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			handler, err := tk.resolveMetricsHandler()
+			if err != nil {
+				t.Fatalf("unexpected handler resolution error: %v", err)
+			}
+			if _, err := tk.newServer(handler); !errors.Is(err, errProtectedRoutePattern) {
+				t.Fatalf("unexpected error: got %v, want %v", err, errProtectedRoutePattern)
+			}
+		})
 	}
 }

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -129,3 +129,60 @@ func TestNewServerRegistersMetricsAndLandingPage(t *testing.T) {
 		t.Fatalf("unexpected landing body: %q", body)
 	}
 }
+
+func TestNewServerRegistersFactoryRoutes(t *testing.T) {
+	tk := New(Config{
+		App:            kingpin.New("test", ""),
+		Name:           "test_exporter",
+		DefaultAddress: ":9100",
+		Logger:         promslog.NewNopLogger(),
+		MetricsHandlerFactory: func(b *Bootstrap) (http.Handler, error) {
+			b.HandleFunc("/probe", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("probe body"))
+			})
+			return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("metrics body"))
+			}), nil
+		},
+	})
+
+	if err := tk.parse([]string{"--web.listen-address=:9100"}); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	handler, err := tk.resolveMetricsHandler()
+	if err != nil {
+		t.Fatalf("unexpected handler resolution error: %v", err)
+	}
+	server, err := tk.newServer(handler)
+	if err != nil {
+		t.Fatalf("unexpected server creation error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	server.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/probe", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected probe status: got %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "probe body" {
+		t.Fatalf("unexpected probe body: got %q", body)
+	}
+}
+
+func TestMetricsPathEnvarOverridesDefault(t *testing.T) {
+	t.Setenv("TEST_EXPORTER_WEB_TELEMETRY_PATH", "/envar-metrics")
+
+	tk := New(Config{
+		App:              kingpin.New("test", ""),
+		DefaultAddress:   ":9100",
+		Logger:           promslog.NewNopLogger(),
+		MetricsPathEnvar: "TEST_EXPORTER_WEB_TELEMETRY_PATH",
+		MetricsHandler:   http.NotFoundHandler(),
+	})
+
+	if err := tk.parse([]string{"--web.listen-address=:9100"}); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if tk.MetricsPath != "/envar-metrics" {
+		t.Fatalf("unexpected metrics path: got %q, want %q", tk.MetricsPath, "/envar-metrics")
+	}
+}

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -169,37 +169,60 @@ func TestNewServerRegistersFactoryRoutes(t *testing.T) {
 	}
 }
 
-func TestNewServerRejectsProtectedRoutePatterns(t *testing.T) {
-	cases := []struct {
-		name    string
-		pattern string
-	}{
-		{name: "metrics path", pattern: "/metrics"},
-		{name: "root path", pattern: "/"},
+func TestNewServerRejectsMetricsPathOverride(t *testing.T) {
+	tk := New(Config{
+		App:            kingpin.New("test", ""),
+		DefaultAddress: ":9100",
+		Logger:         promslog.NewNopLogger(),
+		MetricsHandlerFactory: func(b *Bootstrap) (http.Handler, error) {
+			b.HandleFunc("/metrics", func(http.ResponseWriter, *http.Request) {})
+			return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), nil
+		},
+	})
+
+	if err := tk.parse([]string{"--web.listen-address=:9100"}); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	handler, err := tk.resolveMetricsHandler()
+	if err != nil {
+		t.Fatalf("unexpected handler resolution error: %v", err)
+	}
+	if _, err := tk.newServer(handler); !errors.Is(err, errReservedMetricsPath) {
+		t.Fatalf("unexpected error: got %v, want %v", err, errReservedMetricsPath)
+	}
+}
+
+func TestNewServerAllowsRootRouteOverride(t *testing.T) {
+	tk := New(Config{
+		App:            kingpin.New("test", ""),
+		DefaultAddress: ":9100",
+		Logger:         promslog.NewNopLogger(),
+		MetricsHandlerFactory: func(b *Bootstrap) (http.Handler, error) {
+			b.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("custom root"))
+			})
+			return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), nil
+		},
+	})
+
+	if err := tk.parse([]string{"--web.listen-address=:9100"}); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	handler, err := tk.resolveMetricsHandler()
+	if err != nil {
+		t.Fatalf("unexpected handler resolution error: %v", err)
+	}
+	server, err := tk.newServer(handler)
+	if err != nil {
+		t.Fatalf("unexpected server creation error: %v", err)
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			tk := New(Config{
-				App:            kingpin.New("test", ""),
-				DefaultAddress: ":9100",
-				Logger:         promslog.NewNopLogger(),
-				MetricsHandlerFactory: func(b *Bootstrap) (http.Handler, error) {
-					b.HandleFunc(tc.pattern, func(http.ResponseWriter, *http.Request) {})
-					return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}), nil
-				},
-			})
-
-			if err := tk.parse([]string{"--web.listen-address=:9100"}); err != nil {
-				t.Fatalf("unexpected parse error: %v", err)
-			}
-			handler, err := tk.resolveMetricsHandler()
-			if err != nil {
-				t.Fatalf("unexpected handler resolution error: %v", err)
-			}
-			if _, err := tk.newServer(handler); !errors.Is(err, errProtectedRoutePattern) {
-				t.Fatalf("unexpected error: got %v, want %v", err, errProtectedRoutePattern)
-			}
-		})
+	rec := httptest.NewRecorder()
+	server.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("unexpected root status: got %d, want %d", rec.Code, http.StatusOK)
+	}
+	if body := rec.Body.String(); body != "custom root" {
+		t.Fatalf("unexpected root body: got %q, want the caller's override to take precedence over the landing page", body)
 	}
 }

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -167,22 +167,3 @@ func TestNewServerRegistersFactoryRoutes(t *testing.T) {
 		t.Fatalf("unexpected probe body: got %q", body)
 	}
 }
-
-func TestMetricsPathEnvarOverridesDefault(t *testing.T) {
-	t.Setenv("TEST_EXPORTER_WEB_TELEMETRY_PATH", "/envar-metrics")
-
-	tk := New(Config{
-		App:              kingpin.New("test", ""),
-		DefaultAddress:   ":9100",
-		Logger:           promslog.NewNopLogger(),
-		MetricsPathEnvar: "TEST_EXPORTER_WEB_TELEMETRY_PATH",
-		MetricsHandler:   http.NotFoundHandler(),
-	})
-
-	if err := tk.parse([]string{"--web.listen-address=:9100"}); err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if tk.MetricsPath != "/envar-metrics" {
-		t.Fatalf("unexpected metrics path: got %q, want %q", tk.MetricsPath, "/envar-metrics")
-	}
-}


### PR DESCRIPTION
## Problem

`bootstrap` builds the exporter's HTTP mux itself: `Run()` registers the metrics handler at `--web.telemetry-path` and the landing page at `/`, and nothing else can be added to it.

That is enough for `node_exporter`, but it blocks exporters that serve more than those two endpoints. `postgres_exporter` is the immediate case:

- it serves the multi-target `/probe` endpoint, which is the documented way to scrape remote instances via `auth_modules`
- it exposes the `net/http/pprof` handlers

Adopting `bootstrap` as it stands would silently 404 both, so the exporter cannot move onto the shared startup path without a user-visible regression. Any exporter with a second endpoint hits the same wall, which pushes them back to hand-rolled `main()` blocks — the duplication `bootstrap` exists to remove.

A second constraint is *when* those handlers can be built. `postgres_exporter`'s probe handler needs the logger and the loaded config file, neither of which exists until flags are parsed, so a static list of routes on `Config` is not sufficient.

## Follow-up

Consumed by prometheus-community/postgres_exporter#1368, which moves `postgres_exporter` onto `bootstrap` while keeping `/probe` and pprof working. That PR needs a release of this one before it builds.

Note: an earlier revision of this PR also let exporters back `--web.telemetry-path` with a custom env var, to preserve `postgres_exporter`'s `PG_EXPORTER_WEB_TELEMETRY_PATH`. Per @ArthurSens's review, that's dropped — new env-var-backed flags shouldn't be added, existing ones should be deprecated/removed instead. The follow-up postgres_exporter PR will need to handle that separately.
