### PR TITLE
web: fix nil pointer dereference when systemd socket activation is disabled

### DIFF
--- a/web/flags_test.go
+++ b/web/flags_test.go
@@ -1,0 +1,102 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCheckFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		flags *FlagConfig
+		want  error
+	}{
+		{
+			name:  "nil FlagConfig",
+			flags: nil,
+			want:  ErrMissingFlag,
+		},
+		{
+			name: "missing web config file",
+			flags: &FlagConfig{
+				WebListenAddresses: &[]string{":9100"},
+				WebSystemdSocket:   OfBool(false),
+			},
+			want: ErrMissingFlag,
+		},
+		{
+			name: "listen addresses only",
+			flags: &FlagConfig{
+				WebListenAddresses: &[]string{":9100"},
+				WebConfigFile:      OfString(""),
+			},
+			want: nil,
+		},
+		{
+			name: "systemd socket activation enabled without listen addresses",
+			flags: &FlagConfig{
+				WebSystemdSocket: OfBool(true),
+				WebConfigFile:    OfString(""),
+			},
+			want: nil,
+		},
+		// Regression test: a non-nil but false systemd socket flag used to
+		// satisfy checkFlags, so ListenAndServe went on to dereference the nil
+		// WebListenAddresses and panicked.
+		{
+			name: "systemd socket activation disabled with nil listen addresses",
+			flags: &FlagConfig{
+				WebSystemdSocket: OfBool(false),
+				WebConfigFile:    OfString(""),
+			},
+			want: ErrNoListeners,
+		},
+		{
+			name: "systemd socket activation disabled with empty listen addresses",
+			flags: &FlagConfig{
+				WebListenAddresses: &[]string{},
+				WebSystemdSocket:   OfBool(false),
+				WebConfigFile:      OfString(""),
+			},
+			want: ErrNoListeners,
+		},
+		{
+			name: "no listeners configured at all",
+			flags: &FlagConfig{
+				WebConfigFile: OfString(""),
+			},
+			want: ErrNoListeners,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.flags.checkFlags(); !errors.Is(err, tc.want) {
+				t.Fatalf("checkFlags() = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestListenAndServeNoListeners checks that ListenAndServe reports a missing
+// listener configuration instead of panicking on a nil WebListenAddresses.
+func TestListenAndServeNoListeners(t *testing.T) {
+	flags := &FlagConfig{
+		WebSystemdSocket: OfBool(false),
+		WebConfigFile:    OfString(""),
+	}
+	if err := ListenAndServe(nil, flags, testlogger); !errors.Is(err, ErrNoListeners) {
+		t.Fatalf("ListenAndServe() = %v, want %v", err, ErrNoListeners)
+	}
+}

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -84,8 +84,15 @@ func (c *FlagConfig) checkFlags() error {
 	if c.WebConfigFile == nil {
 		return ErrMissingFlag
 	}
-	if c.WebSystemdSocket == nil && (c.WebListenAddresses == nil || len(*c.WebListenAddresses) == 0) {
-		return ErrNoListeners
+	// Listen addresses are only optional when systemd socket activation is
+	// actually enabled. Checking that WebSystemdSocket is non-nil is not
+	// enough: kingpinflag.AddFlags always hands out a non-nil pointer, so a
+	// nil-but-false flag would otherwise pass validation and then panic on the
+	// *flags.WebListenAddresses dereference in ListenAndServe.
+	if c.WebSystemdSocket == nil || !*c.WebSystemdSocket {
+		if c.WebListenAddresses == nil || len(*c.WebListenAddresses) == 0 {
+			return ErrNoListeners
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
`checkFlags` only required listen addresses to be set when `WebSystemdSocket` was `nil`:

```go
if c.WebSystemdSocket == nil && (c.WebListenAddresses == nil || len(*c.WebListenAddresses) == 0) {
	return ErrNoListeners
}
```

A non-nil pointer to `false` satisfies that condition, so a `FlagConfig` with systemd socket activation explicitly *disabled* and no listen addresses passes validation. `ListenAndServe` then falls through to the port-listener path and panics dereferencing the nil pointer:

```go
listeners := make([]net.Listener, 0, len(*flags.WebListenAddresses))
```

`kingpinflag.AddFlags` always hands out a non-nil `WebSystemdSocket` pointer (it points at `false` on non-Linux), so this is reachable from any caller that builds a `FlagConfig` directly instead of going through the kingpin flags — `FlagConfig` is exported with documented fields, so that is a supported use.

Fix: require listen addresses whenever systemd socket activation is not actually enabled.

`checkFlags`, `ErrNoListeners` and `ErrMissingFlag` had no test coverage at all, so this adds a table test for `checkFlags` plus an end-to-end check that `ListenAndServe` returns `ErrNoListeners` rather than panicking. Reverting the one-line fix makes the new tests fail with the nil dereference panic.
