### PR TITLE
web: fix panic when client_allowed_sans is used with an optional client certificate

### DIFF
--- a/docs/web-configuration.md
+++ b/docs/web-configuration.md
@@ -61,6 +61,10 @@ tls_server_config:
   # which is an exact match to an entry in this list, else terminate the
   # connection. SAN match can be one or multiple of the following: DNS,
   # IP, e-mail, or URI address from https://pkg.go.dev/crypto/x509#Certificate.
+  #
+  # NOTE: This requires client_auth_type to be either RequireAnyClientCert or
+  # RequireAndVerifyClientCert. The other client auth types let a client
+  # connect without sending a certificate, leaving no SAN to match against.
   [ client_allowed_sans:
     [ - <string> ] ]
 

--- a/web/san_test.go
+++ b/web/san_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"testing"
+)
+
+// TestVerifyPeerCertificateWithoutClientCert checks that VerifyPeerCertificate
+// reports a missing client certificate instead of panicking. crypto/tls calls
+// it with an empty slice when the client declines to send a certificate and the
+// configured client auth type does not require one.
+func TestVerifyPeerCertificateWithoutClientCert(t *testing.T) {
+	c := &TLSConfig{ClientAllowedSans: []string{"one"}}
+
+	for _, tc := range []struct {
+		name     string
+		rawCerts [][]byte
+	}{
+		{name: "nil", rawCerts: nil},
+		{name: "empty", rawCerts: [][]byte{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := c.VerifyPeerCertificate(tc.rawCerts, nil)
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !ErrorMap["No client certificate"].MatchString(err.Error()) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestVerifyPeerCertificateHandshakeWithoutClientCert drives a real TLS
+// handshake in which the client presents no certificate, and checks that the
+// server rejects it cleanly rather than panicking in the handshake goroutine.
+func TestVerifyPeerCertificateHandshakeWithoutClientCert(t *testing.T) {
+	cert, err := tls.LoadX509KeyPair("testdata/server.crt", "testdata/server.key")
+	if err != nil {
+		t.Fatalf("loading server key pair: %v", err)
+	}
+
+	tlsConfig := &TLSConfig{ClientAllowedSans: []string{"one"}}
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		// VerifyClientCertIfGiven asks for a certificate but tolerates a
+		// client that does not send one, which is what leaves rawCerts empty.
+		ClientAuth:            tls.VerifyClientCertIfGiven,
+		VerifyPeerCertificate: tlsConfig.VerifyPeerCertificate,
+		MinVersion:            tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	type result struct {
+		err     error
+		recover any
+	}
+	results := make(chan result, 1)
+	go func() {
+		var r result
+		defer func() {
+			r.recover = recover()
+			results <- r
+		}()
+		conn, err := listener.Accept()
+		if err != nil {
+			r.err = err
+			return
+		}
+		defer conn.Close()
+		r.err = conn.(*tls.Conn).Handshake()
+	}()
+
+	caCert, err := os.ReadFile("testdata/tls-ca-chain.pem")
+	if err != nil {
+		t.Fatalf("reading CA chain: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(caCert)
+
+	// Under TLS 1.3 the client completes its side of the handshake before the
+	// server processes the (absent) client certificate, so the dial itself may
+	// succeed and only a later read would surface the server's alert. The
+	// server side is what this test asserts on.
+	clientConn, err := tls.Dial("tcp", listener.Addr().String(), &tls.Config{
+		RootCAs:    pool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	if err == nil {
+		_ = clientConn.Close()
+	}
+
+	r := <-results
+	if r.recover != nil {
+		t.Fatalf("server panicked during the handshake: %v", r.recover)
+	}
+	if r.err == nil {
+		t.Fatal("expected the server to reject a client that sent no certificate")
+	}
+	if !ErrorMap["No client certificate"].MatchString(r.err.Error()) {
+		t.Fatalf("unexpected server error: %v", r.err)
+	}
+}

--- a/web/testdata/web_config_auth_client_san_no_client_auth.bad.yaml
+++ b/web/testdata/web_config_auth_client_san_no_client_auth.bad.yaml
@@ -1,0 +1,5 @@
+tls_server_config:
+  cert_file: "server.crt"
+  key_file: "server.key"
+  client_allowed_sans:
+    - "one"

--- a/web/testdata/web_config_auth_client_san_optional_cert.bad.yaml
+++ b/web/testdata/web_config_auth_client_san_optional_cert.bad.yaml
@@ -1,0 +1,7 @@
+tls_server_config:
+  cert_file: "server.crt"
+  key_file: "server.key"
+  client_auth_type: "VerifyClientCertIfGiven"
+  client_ca_file: "client2_selfsigned.pem"
+  client_allowed_sans:
+    - "one"

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -111,6 +111,13 @@ func (t *TLSConfig) SetDirectory(dir string) {
 
 // VerifyPeerCertificate will check the SAN entries of the client cert if there is configuration for it
 func (t *TLSConfig) VerifyPeerCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+	// crypto/tls calls VerifyPeerCertificate with an empty slice when the
+	// client declines to send a certificate and the client auth type does not
+	// require one. Without this check the rawCerts[0] access below panics.
+	if len(rawCerts) == 0 {
+		return errors.New("client did not present a certificate to match against client_allowed_sans")
+	}
+
 	// sender cert comes first, see https://www.rfc-editor.org/rfc/rfc5246#section-7.4.2
 	cert, err := x509.ParseCertificate(rawCerts[0])
 	if err != nil {
@@ -272,11 +279,6 @@ func ConfigToTLSConfig(c *TLSConfig) (*tls.Config, error) {
 		cfg.ClientCAs = clientCAPool
 	}
 
-	if c.ClientAllowedSans != nil {
-		// verify that the client cert contains an allowed SAN
-		cfg.VerifyPeerCertificate = c.VerifyPeerCertificate
-	}
-
 	switch c.ClientAuth {
 	case "RequestClientCert":
 		cfg.ClientAuth = tls.RequestClientCert
@@ -294,6 +296,20 @@ func ConfigToTLSConfig(c *TLSConfig) (*tls.Config, error) {
 
 	if (c.ClientCAs != "" || c.ClientCAsText != "") && cfg.ClientAuth == tls.NoClientCert {
 		return nil, errors.New("client CA's have been configured without a Client Auth Policy")
+	}
+
+	if c.ClientAllowedSans != nil {
+		// SAN matching is only meaningful when the client is required to
+		// present a certificate. With NoClientCert the server never asks for
+		// one, so VerifyPeerCertificate is never called and the configured
+		// SANs would be silently ignored. With RequestClientCert or
+		// VerifyClientCertIfGiven a client may decline to send a certificate,
+		// leaving nothing to match against.
+		if cfg.ClientAuth != tls.RequireAnyClientCert && cfg.ClientAuth != tls.RequireAndVerifyClientCert {
+			return nil, errors.New("client_allowed_sans requires client_auth_type to be one of RequireAnyClientCert or RequireAndVerifyClientCert")
+		}
+		// verify that the client cert contains an allowed SAN
+		cfg.VerifyPeerCertificate = c.VerifyPeerCertificate
 	}
 
 	return cfg, nil

--- a/web/tls_config_test.go
+++ b/web/tls_config_test.go
@@ -70,6 +70,10 @@ var (
 		"Certificate required": regexp.MustCompile(`certificate required`),
 		"Unknown CA":           regexp.MustCompile(`unknown certificate authority`),
 		"Too Many Requests":    regexp.MustCompile(`Too Many Requests`),
+		"SANs without required client cert": regexp.MustCompile(
+			`client_allowed_sans requires client_auth_type`),
+		"No client certificate": regexp.MustCompile(
+			`client did not present a certificate to match against client_allowed_sans`),
 	}
 )
 
@@ -190,6 +194,16 @@ func TestYAMLFiles(t *testing.T) {
 			Name:           `invalid config yml (bad TLS version)`,
 			YAMLConfigPath: "testdata/web_config_noAuth_wrongTLSVersion.bad.yml",
 			ExpectedError:  ErrorMap["Unknown TLS version"],
+		},
+		{
+			Name:           `invalid config yml (client_allowed_sans with optional client cert)`,
+			YAMLConfigPath: "testdata/web_config_auth_client_san_optional_cert.bad.yaml",
+			ExpectedError:  ErrorMap["SANs without required client cert"],
+		},
+		{
+			Name:           `invalid config yml (client_allowed_sans without client auth)`,
+			YAMLConfigPath: "testdata/web_config_auth_client_san_no_client_auth.bad.yaml",
+			ExpectedError:  ErrorMap["SANs without required client cert"],
 		},
 	}
 	for _, testInputs := range testTables {


### PR DESCRIPTION
`TLSConfig.VerifyPeerCertificate` indexes `rawCerts[0]` without checking the length:

```go
func (t *TLSConfig) VerifyPeerCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) error {
	// sender cert comes first, see https://www.rfc-editor.org/rfc/rfc5246#section-7.4.2
	cert, err := x509.ParseCertificate(rawCerts[0])
```

`crypto/tls` invokes `VerifyPeerCertificate` even when the client sent no certificate, as long as the configured client auth type does not require one. In `processCertsFromClient` the "client didn't provide a certificate" bail-out is guarded by `requiresClientCert(c.config.ClientAuth)`, and control still reaches the unconditional callback at the end of the function with an empty slice.

So this configuration panics for every client that connects without a certificate:

```yaml
tls_server_config:
  cert_file: "server.crt"
  key_file: "server.key"
  client_auth_type: "VerifyClientCertIfGiven"   # or RequestClientCert
  client_ca_file: "client_ca.pem"
  client_allowed_sans:
    - "one"
```

`net/http`'s per-connection `recover` catches it, so the process survives, but the connection is aborted with a stack trace in the log rather than a clean `bad certificate` alert.

**Changes**

1. Return an error instead of panicking when `rawCerts` is empty.
2. Reject the combination at configuration load time. `client_allowed_sans` is only meaningful when the client is *required* to present a certificate — and with `NoClientCert` the callback is never invoked at all, so the configured SANs were silently ignored. That silent-bypass case seems worth failing loudly on, but it is the one behavioural change here, so happy to drop it to just (1) if you'd rather not reject configs that start today.

Docs updated to state the constraint.

**Testing**

Every existing `client_allowed_sans` fixture uses `RequireAndVerifyClientCert`, which is why this went unnoticed. Added a unit test for the nil/empty slice, a real TLS handshake test where the client presents no certificate, and two config fixtures for the rejected combinations. Reverting the guard makes the handshake test fail with `index out of range [0] with length 0`.
