### PR TITLE
web: reject a client CA that holds no certificates

### DIFF
--- a/web/testdata/tls-ca-chain-invalid.pem
+++ b/web/testdata/tls-ca-chain-invalid.pem
@@ -1,0 +1,2 @@
+This file is intentionally not a PEM encoded certificate. It stands in for a
+truncated, DER encoded or otherwise unusable CA bundle.

--- a/web/testdata/web_config_auth_clientCAsText_nocerts.bad.yml
+++ b/web/testdata/web_config_auth_clientCAsText_nocerts.bad.yml
@@ -1,0 +1,5 @@
+tls_server_config:
+  cert_file: "server.crt"
+  key_file: "server.key"
+  client_auth_type: "RequireAndVerifyClientCert"
+  client_ca: "this is not a PEM encoded certificate"

--- a/web/testdata/web_config_auth_clientCAs_nocerts.bad.yml
+++ b/web/testdata/web_config_auth_clientCAs_nocerts.bad.yml
@@ -1,0 +1,5 @@
+tls_server_config:
+  cert_file: "server.crt"
+  key_file: "server.key"
+  client_auth_type: "RequireAndVerifyClientCert"
+  client_ca_file: "tls-ca-chain-invalid.pem"

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -258,17 +258,22 @@ func ConfigToTLSConfig(c *TLSConfig) (*tls.Config, error) {
 		cfg.CurvePreferences = cp
 	}
 
+	// clientCAsEmpty records that a client CA was configured but held no
+	// usable certificate. It is reported after the client auth policy has been
+	// validated, so that a configuration carrying both faults keeps reporting
+	// the policy one.
+	clientCAsEmpty := false
 	if c.ClientCAs != "" {
 		clientCAPool := x509.NewCertPool()
 		clientCAFile, err := os.ReadFile(c.ClientCAs)
 		if err != nil {
 			return nil, err
 		}
-		clientCAPool.AppendCertsFromPEM(clientCAFile)
+		clientCAsEmpty = !clientCAPool.AppendCertsFromPEM(clientCAFile)
 		cfg.ClientCAs = clientCAPool
 	} else if c.ClientCAsText != "" {
 		clientCAPool := x509.NewCertPool()
-		clientCAPool.AppendCertsFromPEM([]byte(c.ClientCAsText))
+		clientCAsEmpty = !clientCAPool.AppendCertsFromPEM([]byte(c.ClientCAsText))
 		cfg.ClientCAs = clientCAPool
 	}
 
@@ -294,6 +299,13 @@ func ConfigToTLSConfig(c *TLSConfig) (*tls.Config, error) {
 
 	if (c.ClientCAs != "" || c.ClientCAsText != "") && cfg.ClientAuth == tls.NoClientCert {
 		return nil, errors.New("client CA's have been configured without a Client Auth Policy")
+	}
+
+	if clientCAsEmpty {
+		if c.ClientCAs != "" {
+			return nil, fmt.Errorf("no client CA certificates found in client_ca_file (%s)", c.ClientCAs)
+		}
+		return nil, errors.New("no client CA certificates found in client_ca")
 	}
 
 	return cfg, nil

--- a/web/tls_config_test.go
+++ b/web/tls_config_test.go
@@ -52,6 +52,7 @@ var (
 		"Invalid Cert or CertPath":     regexp.MustCompile(`missing one of cert or cert_file`),
 		"Invalid Key or KeyPath":       regexp.MustCompile(`missing one of key or key_file`),
 		"ClientCA set without policy":  regexp.MustCompile(`client CA's have been configured without a Client Auth Policy`),
+		"No client CA certificates":    regexp.MustCompile(`no client CA certificates found in client_ca`),
 		"Bad password":                 regexp.MustCompile(`hashedSecret too short to be a bcrypted password`),
 		"Unauthorized":                 regexp.MustCompile(`Unauthorized`),
 		"Forbidden":                    regexp.MustCompile(`Forbidden`),
@@ -170,6 +171,16 @@ func TestYAMLFiles(t *testing.T) {
 			Name:           `invalid config yml (invalid ClientCAs filepath)`,
 			YAMLConfigPath: "testdata/web_config_auth_clientCAs_invalid.bad.yml",
 			ExpectedError:  ErrorMap["No such file"],
+		},
+		{
+			Name:           `invalid config yml (client CA file without certificates)`,
+			YAMLConfigPath: "testdata/web_config_auth_clientCAs_nocerts.bad.yml",
+			ExpectedError:  ErrorMap["No client CA certificates"],
+		},
+		{
+			Name:           `invalid config yml (inline client CA without certificates)`,
+			YAMLConfigPath: "testdata/web_config_auth_clientCAsText_nocerts.bad.yml",
+			ExpectedError:  ErrorMap["No client CA certificates"],
 		},
 		{
 			Name:           `invalid config yml (invalid user list)`,


### PR DESCRIPTION
`x509.CertPool.AppendCertsFromPEM` reports whether it parsed any certificate at all, and both call sites discard it. A `client_ca_file` that exists but holds no usable PEM — a truncated copy, a DER-encoded file, a path pointing at the wrong artifact — is accepted and produces a pool with no subjects. The same applies to an inline `client_ca`.

Under `RequireAndVerifyClientCert` this fails closed, so it is not an authentication bypass. But the operator gets a server that rejects every client with an opaque handshake error, while `Validate` reports the configuration as good.

Reproduced against master: a CA file containing the literal text `this is definitely not a PEM certificate` was accepted, and the resulting pool had 0 subjects.

### Ordering

The emptiness check runs after the client auth policy has been validated. Two existing fixtures pin the ordering from opposite directions — one configures a readable but empty CA with no policy and expects the policy error, the other configures a missing CA file with no policy and expects the read error. Reporting emptiness last keeps both reporting what they did before.

### Tests

`web_config_auth_clientCAs_invalid.bad.yml` only covers a *missing* file, which is why this went unnoticed. Added fixtures for a file that parses to nothing and for the inline equivalent; both fail against master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)