### PR TITLE
web: set the configured headers on rate limited responses

### DIFF
--- a/web/handler.go
+++ b/web/handler.go
@@ -95,14 +95,16 @@ func (u *webHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Configure http headers. This happens before any request is turned away,
+	// so that the configured headers are present on every response and not
+	// only on the ones that reach the wrapped handler.
+	for k, v := range c.HTTPConfig.Header {
+		w.Header().Set(k, v)
+	}
+
 	if u.limiter != nil && !u.limiter.Allow() {
 		http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
 		return
-	}
-
-	// Configure http headers.
-	for k, v := range c.HTTPConfig.Header {
-		w.Header().Set(k, v)
 	}
 
 	if len(c.Users) == 0 {

--- a/web/headers_test.go
+++ b/web/headers_test.go
@@ -1,0 +1,84 @@
+// Copyright The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// TestHeadersOnRateLimitedResponse checks that the configured headers are set
+// on a response that the rate limiter turns away. A header policy such as
+// Strict-Transport-Security is meant to hold for every response from the
+// endpoint, not only for the ones that are served.
+func TestHeadersOnRateLimitedResponse(t *testing.T) {
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte("Hello World!"))
+		}),
+	}
+
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		if err := server.Shutdown(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		<-done
+	})
+
+	go func() {
+		flags := FlagConfig{
+			WebListenAddresses: &([]string{port}),
+			WebSystemdSocket:   OfBool(false),
+			WebConfigFile:      OfString("testdata/web_config_rate_limiter_headers.yaml"),
+		}
+		ListenAndServe(server, &flags, testlogger)
+		close(done)
+	}()
+
+	waitForPort(t, port)
+
+	// The burst is 1 over an interval of an hour, so the first request is
+	// served and every one after it is rate limited.
+	get := func() *http.Response {
+		t.Helper()
+		r, err := http.Get("http://localhost" + port)
+		if err != nil {
+			t.Fatal(err)
+		}
+		r.Body.Close()
+		return r
+	}
+
+	served := get()
+	if served.StatusCode != http.StatusOK {
+		t.Fatalf("first request: got status %d, expected %d", served.StatusCode, http.StatusOK)
+	}
+
+	limited := get()
+	if limited.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("second request: got status %d, expected %d", limited.StatusCode, http.StatusTooManyRequests)
+	}
+
+	for _, header := range []string{"X-Frame-Options", "Strict-Transport-Security"} {
+		want := served.Header.Get(header)
+		if want == "" {
+			t.Fatalf("%s was not set on the served response", header)
+		}
+		if got := limited.Header.Get(header); got != want {
+			t.Errorf("%s on the rate limited response = %q, expected %q", header, got, want)
+		}
+	}
+}

--- a/web/testdata/web_config_rate_limiter_headers.yaml
+++ b/web/testdata/web_config_rate_limiter_headers.yaml
@@ -1,0 +1,7 @@
+rate_limit:
+  interval: 1h
+  burst: 1
+http_server_config:
+  headers:
+    X-Frame-Options: deny
+    Strict-Transport-Security: max-age=31536000; includeSubDomains


### PR DESCRIPTION
The rate limiter is checked before the loop that applies `http_server_config.headers`, so a 429 is written without them. A request that is served carries the operator's `Strict-Transport-Security`, `Content-Security-Policy` and `X-Frame-Options`; a request from the same client a moment later does not.

A header policy is meant to hold for every response from the endpoint, so apply the headers first and turn the request away afterwards.

One note for anyone checking this by hand: `X-Content-Type-Options` hides the difference, because `http.Error` sets `nosniff` itself, so it was present on the 429 either way. The test uses `X-Frame-Options` and `Strict-Transport-Security`.

### Tests

Added a test that spends a burst of 1, then compares the headers on the served response with those on the rate-limited one. It fails against master with both headers empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)