### PR TITLE
web: mark prefer_server_cipher_suites as deprecated and ignored

### DIFF
--- a/docs/web-configuration.md
+++ b/docs/web-configuration.md
@@ -80,10 +80,13 @@ tls_server_config:
   [ cipher_suites:
     [ - <string> ] ]
 
-  # prefer_server_cipher_suites controls whether the server selects the
-  # client's most preferred ciphersuite, or the server's most preferred
-  # ciphersuite. If true then the server's preference, as expressed in
-  # the order of elements in cipher_suites, is used.
+  # Deprecated: this setting is accepted and ignored.
+  #
+  # It used to control whether the server followed its own cipher suite
+  # preference, as expressed in the order of elements in cipher_suites, or the
+  # client's. Go has selected the cipher suite itself since Go 1.17, taking
+  # into account inferred client hardware, server hardware and security, and
+  # the underlying setting has had no effect since then.
   [ prefer_server_cipher_suites: <bool> | default = true ]
 
   # Elliptic curves that will be used in an ECDHE handshake, in preference

--- a/web/tls_config.go
+++ b/web/tls_config.go
@@ -51,19 +51,25 @@ type Config struct {
 }
 
 type TLSConfig struct {
-	TLSCert                  string             `yaml:"cert"`
-	TLSKey                   config_util.Secret `yaml:"key"`
-	ClientCAsText            string             `yaml:"client_ca"`
-	TLSCertPath              string             `yaml:"cert_file"`
-	TLSKeyPath               string             `yaml:"key_file"`
-	ClientAuth               string             `yaml:"client_auth_type"`
-	ClientCAs                string             `yaml:"client_ca_file"`
-	CipherSuites             []Cipher           `yaml:"cipher_suites"`
-	CurvePreferences         []Curve            `yaml:"curve_preferences"`
-	MinVersion               TLSVersion         `yaml:"min_version"`
-	MaxVersion               TLSVersion         `yaml:"max_version"`
-	PreferServerCipherSuites bool               `yaml:"prefer_server_cipher_suites"`
-	ClientAllowedSans        []string           `yaml:"client_allowed_sans"`
+	TLSCert          string             `yaml:"cert"`
+	TLSKey           config_util.Secret `yaml:"key"`
+	ClientCAsText    string             `yaml:"client_ca"`
+	TLSCertPath      string             `yaml:"cert_file"`
+	TLSKeyPath       string             `yaml:"key_file"`
+	ClientAuth       string             `yaml:"client_auth_type"`
+	ClientCAs        string             `yaml:"client_ca_file"`
+	CipherSuites     []Cipher           `yaml:"cipher_suites"`
+	CurvePreferences []Curve            `yaml:"curve_preferences"`
+	MinVersion       TLSVersion         `yaml:"min_version"`
+	MaxVersion       TLSVersion         `yaml:"max_version"`
+	// PreferServerCipherSuites is parsed and ignored.
+	//
+	// Deprecated: it used to be passed to tls.Config, whose field of the same
+	// name has had no effect since Go 1.17. crypto/tls now picks the cipher
+	// suite itself. The key is still accepted so that existing configuration
+	// files keep loading.
+	PreferServerCipherSuites bool     `yaml:"prefer_server_cipher_suites"`
+	ClientAllowedSans        []string `yaml:"client_allowed_sans"`
 }
 
 type FlagConfig struct {
@@ -232,10 +238,11 @@ func ConfigToTLSConfig(c *TLSConfig) (*tls.Config, error) {
 		return nil, err
 	}
 
+	// c.PreferServerCipherSuites is deliberately not passed on: the tls.Config
+	// field of that name has had no effect since Go 1.17.
 	cfg := &tls.Config{
-		MinVersion:               (uint16)(c.MinVersion),
-		MaxVersion:               (uint16)(c.MaxVersion),
-		PreferServerCipherSuites: c.PreferServerCipherSuites,
+		MinVersion: (uint16)(c.MinVersion),
+		MaxVersion: (uint16)(c.MaxVersion),
 	}
 
 	cfg.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {


### PR DESCRIPTION
The documentation gives `prefer_server_cipher_suites` a four-line explanation of how it changes cipher selection, and it has not done anything for years.

It is passed to `tls.Config.PreferServerCipherSuites`, whose own documentation reads:

> PreferServerCipherSuites is a legacy field and has no effect.

Go has selected the cipher suite itself since Go 1.17. Operators tuning this are tuning a knob that is not connected to anything.

### Change

Say so in the documentation and on the struct field, and stop passing the value to `tls.Config` — which also removes a use of a deprecated standard library field. The YAML key is still parsed and still defaults to `true`, so existing configuration files keep loading unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)